### PR TITLE
Remove obsolete import hacks

### DIFF
--- a/showup_tools/simplified_app.py
+++ b/showup_tools/simplified_app.py
@@ -11,59 +11,7 @@ import json
 import pandas as pd
 import queue
 
-# ---------------------------------------------------------------------------
-# Path setup
-# ---------------------------------------------------------------------------
-CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-PARENT_DIR = os.path.dirname(CURRENT_DIR)
-REPO_ROOT = os.path.dirname(PARENT_DIR)
-
-_PATHS = [
-    CURRENT_DIR,
-    PARENT_DIR,
-    REPO_ROOT,
-    os.path.join(REPO_ROOT, "showup-core"),
-    os.path.join(REPO_ROOT, "showup-editor-ui"),
-]
-
-for _p in _PATHS:
-    if _p not in sys.path:
-        sys.path.insert(0, _p)
-
-# Handle the ``showup_tools`` vs ``showup-tools`` directory name difference
-import importlib.util
-
-
-class ShowupToolsPathFinder:
-    """Resolve imports for the ``showup_tools`` namespace."""
-
-    @classmethod
-    def find_spec(cls, fullname, path=None, target=None):
-        if fullname == "showup_tools" or fullname.startswith("showup_tools."):
-            parts = fullname.split(".")
-            if len(parts) > 1:
-                subpath = os.path.join(*parts[1:])
-                filepath = os.path.join(REPO_ROOT, "showup-tools", subpath)
-            else:
-                filepath = os.path.join(REPO_ROOT, "showup-tools")
-
-            if os.path.isdir(filepath):
-                filename = os.path.join(filepath, "__init__.py")
-                submodule_locations = [filepath]
-            else:
-                filename = filepath + ".py"
-                submodule_locations = None
-
-            if os.path.exists(filename):
-                return importlib.util.spec_from_file_location(
-                    fullname,
-                    filename,
-                    submodule_search_locations=submodule_locations,
-                )
-        return None
-
-
-sys.meta_path.insert(0, ShowupToolsPathFinder)
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 from showup_core.core.log_utils import get_log_path
 if os.name == 'nt':

--- a/showup_tools/simplified_app/simplified_app.py
+++ b/showup_tools/simplified_app/simplified_app.py
@@ -11,59 +11,7 @@ import json
 import pandas as pd
 import queue
 
-# ---------------------------------------------------------------------------
-# Path setup
-# ---------------------------------------------------------------------------
-CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-PARENT_DIR = os.path.dirname(CURRENT_DIR)
-REPO_ROOT = os.path.dirname(PARENT_DIR)
-
-_PATHS = [
-    CURRENT_DIR,
-    PARENT_DIR,
-    REPO_ROOT,
-    os.path.join(REPO_ROOT, "showup-core"),
-    os.path.join(REPO_ROOT, "showup-editor-ui"),
-]
-
-for _p in _PATHS:
-    if _p not in sys.path:
-        sys.path.insert(0, _p)
-
-# Handle the ``showup_tools`` vs ``showup-tools`` directory name difference
-import importlib.util
-
-
-class ShowupToolsPathFinder:
-    """Resolve imports for the ``showup_tools`` namespace."""
-
-    @classmethod
-    def find_spec(cls, fullname, path=None, target=None):
-        if fullname == "showup_tools" or fullname.startswith("showup_tools."):
-            parts = fullname.split(".")
-            if len(parts) > 1:
-                subpath = os.path.join(*parts[1:])
-                filepath = os.path.join(REPO_ROOT, "showup-tools", subpath)
-            else:
-                filepath = os.path.join(REPO_ROOT, "showup-tools")
-
-            if os.path.isdir(filepath):
-                filename = os.path.join(filepath, "__init__.py")
-                submodule_locations = [filepath]
-            else:
-                filename = filepath + ".py"
-                submodule_locations = None
-
-            if os.path.exists(filename):
-                return importlib.util.spec_from_file_location(
-                    fullname,
-                    filename,
-                    submodule_search_locations=submodule_locations,
-                )
-        return None
-
-
-sys.meta_path.insert(0, ShowupToolsPathFinder)
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 from showup_core.core.log_utils import get_log_path
 if os.name == 'nt':


### PR DESCRIPTION
## Summary
- clean up simplified app path setup
- remove `ShowupToolsPathFinder`

## Testing
- `pytest tests/test_claude_modules.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6870c2a81d188326a9f112ce1d4ade38