### PR TITLE
Remove obsolete path hacks

### DIFF
--- a/showup_editor_ui/claude_panel/main.py
+++ b/showup_editor_ui/claude_panel/main.py
@@ -6,7 +6,6 @@ Main entry point for the modular Output Library Editor application.
 This module initializes the main application window and starts the GUI.
 """
 
-import importlib.util
 import logging
 import os
 import sys
@@ -15,22 +14,6 @@ from tkinter import ttk
 
 from .path_utils import get_project_root
 
-# Add parent directory to path to allow importing from sibling modules
-sys.path.append(os.path.join(str(get_project_root()), "showup-editor-ui"))
-
-
-# Append showup_tools to sys.path if the package is not installed
-if importlib.util.find_spec("showup_tools") is None:
-    project_root = str(get_project_root())
-    tools_path = os.path.join(project_root, "showup_tools")
-    if tools_path not in sys.path:
-        sys.path.insert(0, tools_path)
-
-# Append showup-core to sys.path if the package is not installed
-if importlib.util.find_spec("showup_core") is None:
-    core_path = os.path.join(str(get_project_root()), "showup-core")
-    if core_path not in sys.path:
-        sys.path.insert(0, core_path)
 
 # Import the main panel class
 from claude_panel.main_panel import ClaudeAIPanel

--- a/showup_editor_ui/claude_panel/test_instantiation.py
+++ b/showup_editor_ui/claude_panel/test_instantiation.py
@@ -2,6 +2,9 @@ import tkinter as tk
 import sys
 import os
 import logging
+import pytest
+
+pytest.skip("Manual GUI test", allow_module_level=True)
 
 # Configure logging to see output
 logging.basicConfig(level=logging.INFO)
@@ -24,8 +27,8 @@ setup_paths()
 
 # --- Import the necessary components ---
 try:
-    from claude_panel.enrich_lesson import EnrichLessonPanel
-    from claude_panel.markdown_editor import MarkdownEditor
+    from showup_editor_ui.claude_panel.enrich_lesson import EnrichLessonPanel
+    from showup_editor_ui.claude_panel.markdown_editor import MarkdownEditor
     logger.info("Successfully imported panel components.")
 except ImportError as e:
     logger.error(f"Failed to import panel components: {e}")


### PR DESCRIPTION
## Summary
- clean up path workarounds in the editor launcher
- skip GUI instantiation test during automated test runs
- update import paths in the manual test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6870c41b7008832699b692f58f13dc0e