### PR TITLE
Fix venv activation path in launch scripts

### DIFF
--- a/showup_tools/run_simplified_app.bat
+++ b/showup_tools/run_simplified_app.bat
@@ -42,7 +42,7 @@ if not exist "venv" (
 
 REM Activate the virtual environment
 echo [INFO] Activating virtual environment...
-call "venv\Scripts\activate.bat"
+call "%~dp0venv\Scripts\activate.bat"
 
 REM Install all dependencies from the central requirements.txt file
 echo [INFO] Installing/updating dependencies from !REQUIREMENTS_FILE!...

--- a/showup_tools/simplified_app/run_simplified_app.bat
+++ b/showup_tools/simplified_app/run_simplified_app.bat
@@ -7,7 +7,7 @@ cd /d "%~dp0\..\.."
 
 REM --- Activate Virtual Environment ---
 ECHO Activating virtual environment...
-CALL venv\Scripts\activate.bat
+CALL "%~dp0venv\Scripts\activate.bat"
 
 REM --- Install the project in editable mode ---
 ECHO Installing project in editable mode...
@@ -19,7 +19,7 @@ python -m showup_tools.simplified_app.simplified_app
 
 REM --- Deactivate ---
 ECHO Deactivating virtual environment...
-CALL venv\Scripts\deactivate.bat
+CALL "%~dp0venv\Scripts\deactivate.bat"
 
 endlocal
 pause


### PR DESCRIPTION
## Summary
- fix activate/deactivate paths in run_simplified_app.bat scripts to be relative to script location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6870ce5d5d6483269b2c26676b777f90