### PR TITLE
Add claude_api dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "1.0.0"
 requires-python = ">=3.8"
 dependencies = [
     "anthropic",
+    "claude_api",
     "loguru",
     "numpy",
     "pandas",


### PR DESCRIPTION
## Summary
- add missing `claude_api` to project dependencies

## Testing
- `pip install claude_api`
- `pip install -e . --no-deps`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6870cecc4c288326978f20efdbcb297b