### PR TITLE
Implement planning stage function

### DIFF
--- a/showup_tools/__init__.py
+++ b/showup_tools/__init__.py
@@ -1,1 +1,2 @@
 # Initialize the simplified_app package
+from .planning_stage import run_planning_stage

--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -1,0 +1,60 @@
+import os
+import json
+import logging
+import asyncio
+from typing import Dict, Any
+
+from .showup_core.api_client import generate_with_claude
+from .showup_core.model_config import get_model_provider
+
+logger = logging.getLogger(__name__)
+
+PLANNING_PROMPT_PATH = os.path.join(os.path.dirname(__file__), 'prompts', 'planning_prompt.txt')
+
+async def run_planning_stage(row_data_item: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+    """Generate a preliminary plan using either Anthropic or OpenAI models."""
+    logger.info("Running planning stage")
+
+    try:
+        with open(PLANNING_PROMPT_PATH, 'r', encoding='utf-8') as f:
+            prompt_template = f.read()
+    except FileNotFoundError:
+        logger.error(f"Planning prompt not found: {PLANNING_PROMPT_PATH}")
+        row_data_item['status'] = 'PLAN_FAILED'
+        row_data_item['error'] = f"Prompt not found: {PLANNING_PROMPT_PATH}"
+        return row_data_item
+
+    content_outline = row_data_item.get('Content Outline') or row_data_item.get('content_outline', '')
+    prompt = prompt_template.replace('{{content_outline}}', content_outline)
+
+    model_id = config.get('model_id', 'claude-3-haiku-20240307')
+    provider = get_model_provider(model_id)
+
+    try:
+        if provider == 'openai':
+            import openai
+            client = openai.OpenAI(api_key=config.get('openai_api_key'))
+            response = client.chat.completions.create(
+                model=model_id,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=config.get('max_tokens', 1000),
+                temperature=config.get('temperature', 0.3)
+            )
+            ai_response = response.choices[0].message.content
+        else:
+            ai_response = await generate_with_claude(
+                prompt,
+                max_tokens=config.get('max_tokens', 1000),
+                temperature=config.get('temperature', 0.3),
+                model=model_id,
+                task_type='planning'
+            )
+
+        row_data_item['initial_plan'] = json.loads(ai_response)
+        row_data_item['status'] = 'PLAN_GENERATED'
+    except Exception as e:
+        logger.error(f"Planning stage failed: {e}")
+        row_data_item['status'] = 'PLAN_FAILED'
+        row_data_item['error'] = str(e)
+
+    return row_data_item

--- a/showup_tools/prompts/planning_prompt.txt
+++ b/showup_tools/prompts/planning_prompt.txt
@@ -1,0 +1,4 @@
+You are a planning assistant tasked with creating a lesson plan.
+Use the following outline:
+{{content_outline}}
+Respond with a JSON object representing the plan.

--- a/tests/test_planning_stage.py
+++ b/tests/test_planning_stage.py
@@ -1,0 +1,51 @@
+import unittest
+import asyncio
+import importlib
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+# setup paths similar to other tests
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+paths = [os.path.join(root_dir, 'showup_tools'), root_dir]
+for p in paths:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+# provide stub for openai if missing
+if 'openai' not in sys.modules:
+    sys.modules['openai'] = MagicMock()
+
+from showup_tools.planning_stage import run_planning_stage
+
+class TestPlanningStage(unittest.TestCase):
+    def test_planning_with_claude(self):
+        row = {"content_outline": "Outline"}
+        config = {"model_id": "claude-3-haiku-20240307"}
+        with patch('showup_tools.planning_stage.generate_with_claude') as mock_claude:
+            mock_claude.return_value = '{"plan": "ok"}'
+            result = asyncio.run(run_planning_stage(row, config))
+        self.assertEqual(result['status'], 'PLAN_GENERATED')
+        self.assertEqual(result['initial_plan']['plan'], 'ok')
+        mock_claude.assert_called()
+
+    def test_planning_with_openai(self):
+        row = {"content_outline": "Outline"}
+        config = {"model_id": "gpt-4", "openai_api_key": "x"}
+
+        mock_resp = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = '{"plan": "ok"}'
+        mock_resp.choices = [mock_choice]
+
+        with patch('openai.OpenAI') as mock_openai:
+            client = mock_openai.return_value
+            client.chat.completions.create.return_value = mock_resp
+            result = asyncio.run(run_planning_stage(row, config))
+
+        self.assertEqual(result['status'], 'PLAN_GENERATED')
+        self.assertEqual(result['initial_plan']['plan'], 'ok')
+        mock_openai.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `run_planning_stage` async helper
- load planning prompt from new prompts directory
- support OpenAI and Claude models
- expose the new function via package `__init__`
- add unit tests covering both providers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6870fce9c83c8326813f09db0948778e