### PR TITLE
Add refinement stage with tests

### DIFF
--- a/showup_tools/__init__.py
+++ b/showup_tools/__init__.py
@@ -1,2 +1,8 @@
 # Initialize the simplified_app package
 from .planning_stage import run_planning_stage
+from .refinement_stage import run_refinement_stage
+
+__all__ = [
+    'run_planning_stage',
+    'run_refinement_stage',
+]

--- a/showup_tools/prompts/plan_critique_prompt.txt
+++ b/showup_tools/prompts/plan_critique_prompt.txt
@@ -1,0 +1,9 @@
+You are an expert instructional designer. Review the plan below for the given learner profile and provide a short critique.
+
+Learner Profile:
+{{learner_profile}}
+
+Plan:
+{{initial_plan}}
+
+Critique:

--- a/showup_tools/prompts/plan_refine_prompt.txt
+++ b/showup_tools/prompts/plan_refine_prompt.txt
@@ -1,0 +1,12 @@
+You are an expert instructional designer. Using the learner profile and critique, improve the initial plan.
+
+Learner Profile:
+{{learner_profile}}
+
+Initial Plan:
+{{initial_plan}}
+
+Critique:
+{{critique}}
+
+Respond with a JSON object representing the revised plan.

--- a/showup_tools/refinement_stage.py
+++ b/showup_tools/refinement_stage.py
@@ -1,0 +1,89 @@
+import os
+import json
+import logging
+from typing import Dict, Any
+
+from .showup_core.api_client import generate_with_claude
+from .showup_core.model_config import get_model_provider
+
+logger = logging.getLogger(__name__)
+
+PROMPTS_DIR = os.path.join(os.path.dirname(__file__), 'prompts')
+CRITIQUE_PROMPT_PATH = os.path.join(PROMPTS_DIR, 'plan_critique_prompt.txt')
+REFINE_PROMPT_PATH = os.path.join(PROMPTS_DIR, 'plan_refine_prompt.txt')
+
+async def run_refinement_stage(row_data_item: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+    """Critique and refine an initial plan using either Anthropic or OpenAI models."""
+    logger.info("Running refinement stage")
+
+    try:
+        with open(CRITIQUE_PROMPT_PATH, 'r', encoding='utf-8') as f:
+            critique_template = f.read()
+        with open(REFINE_PROMPT_PATH, 'r', encoding='utf-8') as f:
+            refine_template = f.read()
+    except FileNotFoundError as e:
+        logger.error(f"Refinement prompt not found: {e}")
+        row_data_item['status'] = 'PLAN_FAILED'
+        row_data_item['error'] = f"Prompt not found: {e}"
+        return row_data_item
+
+    learner_profile = row_data_item.get('Learner Profile') or row_data_item.get('learner_profile', '')
+    initial_plan_obj = row_data_item.get('initial_plan', {})
+    initial_plan_str = json.dumps(initial_plan_obj, ensure_ascii=False)
+
+    critique_prompt = critique_template.replace('{{learner_profile}}', learner_profile)
+    critique_prompt = critique_prompt.replace('{{initial_plan}}', initial_plan_str)
+
+    model_id = config.get('model_id', 'claude-3-haiku-20240307')
+    provider = get_model_provider(model_id)
+
+    try:
+        if provider == 'openai':
+            import openai
+            client = openai.OpenAI(api_key=config.get('openai_api_key'))
+            response = client.chat.completions.create(
+                model=model_id,
+                messages=[{"role": "user", "content": critique_prompt}],
+                max_tokens=config.get('max_tokens', 1000),
+                temperature=config.get('temperature', 0.3)
+            )
+            critique = response.choices[0].message.content
+        else:
+            critique = await generate_with_claude(
+                critique_prompt,
+                max_tokens=config.get('max_tokens', 1000),
+                temperature=config.get('temperature', 0.3),
+                model=model_id,
+                task_type='plan_critique'
+            )
+        row_data_item['plan_critique'] = critique
+
+        refine_prompt = refine_template.replace('{{learner_profile}}', learner_profile)
+        refine_prompt = refine_prompt.replace('{{initial_plan}}', initial_plan_str)
+        refine_prompt = refine_prompt.replace('{{critique}}', critique)
+
+        if provider == 'openai':
+            response2 = client.chat.completions.create(
+                model=model_id,
+                messages=[{"role": "user", "content": refine_prompt}],
+                max_tokens=config.get('max_tokens', 1000),
+                temperature=config.get('temperature', 0.3)
+            )
+            revised_plan_text = response2.choices[0].message.content
+        else:
+            revised_plan_text = await generate_with_claude(
+                refine_prompt,
+                max_tokens=config.get('max_tokens', 1000),
+                temperature=config.get('temperature', 0.3),
+                model=model_id,
+                task_type='plan_refine'
+            )
+
+        row_data_item['final_plan'] = json.loads(revised_plan_text)
+        row_data_item['status'] = 'PLAN_FINALIZED'
+    except Exception as e:
+        logger.error(f"Refinement stage failed: {e}")
+        row_data_item['status'] = 'PLAN_FAILED'
+        row_data_item['error'] = str(e)
+
+    return row_data_item

--- a/tests/test_refinement_stage.py
+++ b/tests/test_refinement_stage.py
@@ -1,0 +1,58 @@
+import unittest
+import asyncio
+import importlib
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+# setup paths similar to other tests
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+paths = [os.path.join(root_dir, 'showup_tools'), root_dir]
+for p in paths:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+# provide stub for openai if missing
+if 'openai' not in sys.modules:
+    sys.modules['openai'] = MagicMock()
+
+from showup_tools.refinement_stage import run_refinement_stage
+
+class TestRefinementStage(unittest.TestCase):
+    def test_refinement_with_claude(self):
+        row = {"initial_plan": {"plan": "orig"}, "learner_profile": "profile"}
+        config = {"model_id": "claude-3-haiku-20240307"}
+        with patch('showup_tools.refinement_stage.generate_with_claude') as mock_claude:
+            mock_claude.side_effect = ['critique', '{"plan": "improved"}']
+            result = asyncio.run(run_refinement_stage(row, config))
+        self.assertEqual(result['status'], 'PLAN_FINALIZED')
+        self.assertEqual(result['plan_critique'], 'critique')
+        self.assertEqual(result['final_plan']['plan'], 'improved')
+        self.assertEqual(mock_claude.call_count, 2)
+
+    def test_refinement_with_openai(self):
+        row = {"initial_plan": {"plan": "orig"}, "learner_profile": "profile"}
+        config = {"model_id": "gpt-4", "openai_api_key": "x"}
+
+        mock_resp1 = MagicMock()
+        mock_choice1 = MagicMock()
+        mock_choice1.message.content = 'critique'
+        mock_resp1.choices = [mock_choice1]
+
+        mock_resp2 = MagicMock()
+        mock_choice2 = MagicMock()
+        mock_choice2.message.content = '{"plan": "improved"}'
+        mock_resp2.choices = [mock_choice2]
+
+        with patch('openai.OpenAI') as mock_openai:
+            client = mock_openai.return_value
+            client.chat.completions.create.side_effect = [mock_resp1, mock_resp2]
+            result = asyncio.run(run_refinement_stage(row, config))
+
+        self.assertEqual(result['status'], 'PLAN_FINALIZED')
+        self.assertEqual(result['plan_critique'], 'critique')
+        self.assertEqual(result['final_plan']['plan'], 'improved')
+        mock_openai.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `run_refinement_stage` for plan critique/refinement
- expose new function in `showup_tools` package
- add prompts for plan critique and refinement
- include unit tests covering Claude and OpenAI flows

## Testing
- `pytest tests/test_refinement_stage.py::TestRefinementStage::test_refinement_with_claude -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871015b28248326a0656631ff1a5558