### PR TITLE
Implement generation stage from final plan

### DIFF
--- a/showup_tools/prompts/generation_prompt.txt
+++ b/showup_tools/prompts/generation_prompt.txt
@@ -1,0 +1,2 @@
+Write an educational video script based on the following finalized plan:
+{{final_plan}}

--- a/showup_tools/showup_core/api_client.py
+++ b/showup_tools/showup_core/api_client.py
@@ -253,7 +253,8 @@ async def generate_with_claude(prompt: str, max_tokens: int = 4000, temperature:
                            model: Optional[str] = None, use_cache: bool = True,
                            task_type: str = "content_generation", system_prompt: str = "",
                            module_number: int = None, lesson_number: int = None,
-                          step_number: int = None) -> str:
+                           step_number: int = None, frequency_penalty: float = 0.0,
+                           presence_penalty: float = 0.0) -> str:
     """
     Generate content using Anthropic's Claude API.
     

--- a/tests/test_generation_stage.py
+++ b/tests/test_generation_stage.py
@@ -1,0 +1,51 @@
+import unittest
+import asyncio
+import json
+import importlib
+import sys
+import os
+from unittest.mock import patch, mock_open
+
+# setup paths similar to other tests
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+paths = [os.path.join(root_dir, 'showup_tools'), root_dir]
+for p in paths:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+# remove stale namespace packages that may block imports
+if 'showup_core' in sys.modules:
+    del sys.modules['showup_core']
+
+from showup_tools.content_generator import generate_three_versions_from_plan
+
+class TestGenerationStage(unittest.TestCase):
+    def test_generate_three_versions_from_plan(self):
+        final_plan = {"plan": "test"}
+        ui_settings = {
+            "generation_settings": {
+                "max_tokens": 1000,
+                "frequency_penalty": 0.1,
+                "presence_penalty": 0.2
+            },
+            "selected_model": "test-model"
+        }
+        prompt_text = "Script based on {{final_plan}}"
+        m = mock_open(read_data=prompt_text)
+        with patch("builtins.open", m):
+            with patch("showup_tools.content_generator.generate_with_claude") as mock_gen:
+                mock_gen.side_effect = ["v1", "v2", "v3"]
+                result = asyncio.run(generate_three_versions_from_plan(final_plan, ui_settings))
+
+        self.assertEqual(result, ["v1", "v2", "v3"])
+        self.assertEqual(mock_gen.call_count, 3)
+        called_args = mock_gen.call_args_list[0][1]
+        self.assertEqual(called_args["max_tokens"], 1000)
+        self.assertEqual(called_args["temperature"], 0.3)
+        self.assertEqual(called_args["model"], "test-model")
+        self.assertEqual(called_args["frequency_penalty"], 0.1)
+        self.assertEqual(called_args["presence_penalty"], 0.2)
+        self.assertIn(json.dumps(final_plan), mock_gen.call_args_list[0][1]["prompt"])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add failing test for generation stage update
- implement generate_three_versions_from_plan
- support frequency/presence penalties in `generate_with_claude`
- update workflow to use finalized plan
- add prompt template for generation

## Testing
- `pytest tests/test_generation_stage.py::TestGenerationStage::test_generate_three_versions_from_plan -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871079aeeec83268e7ddb3bf4df9770