### PR TITLE
Integrate planning and refinement stages into workflow

### DIFF
--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -9,22 +9,32 @@ from .showup_core.model_config import get_model_provider
 
 logger = logging.getLogger(__name__)
 
-PLANNING_PROMPT_PATH = os.path.join(os.path.dirname(__file__), 'prompts', 'planning_prompt.txt')
+PLANNING_PROMPT_PATH = os.path.join(
+    os.path.dirname(__file__), "prompts", "planning_prompt.txt"
+)
 
-async def run_planning_stage(row_data_item: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+async def run_planning_stage(
+    row_data_item: Dict[str, Any], config: Dict[str, Any]
+) -> Dict[str, Any]:
     """Generate a preliminary plan using either Anthropic or OpenAI models."""
     logger.info("Running planning stage")
 
+    new_item = row_data_item.copy()
+
+    prompt_path = config.get("planning_prompt_path", PLANNING_PROMPT_PATH)
+
     try:
-        with open(PLANNING_PROMPT_PATH, 'r', encoding='utf-8') as f:
+        with open(prompt_path, "r", encoding="utf-8") as f:
             prompt_template = f.read()
     except FileNotFoundError:
-        logger.error(f"Planning prompt not found: {PLANNING_PROMPT_PATH}")
-        row_data_item['status'] = 'PLAN_FAILED'
-        row_data_item['error'] = f"Prompt not found: {PLANNING_PROMPT_PATH}"
-        return row_data_item
+        logger.error(f"Planning prompt not found: {prompt_path}")
+        new_item["status"] = "PLAN_FAILED"
+        new_item["error"] = f"Prompt not found: {prompt_path}"
+        return new_item
 
-    content_outline = row_data_item.get('Content Outline') or row_data_item.get('content_outline', '')
+    content_outline = new_item.get("Content Outline") or new_item.get(
+        "content_outline", ""
+    )
     prompt = prompt_template.replace('{{content_outline}}', content_outline)
 
     model_id = config.get('model_id', 'claude-3-haiku-20240307')
@@ -50,11 +60,11 @@ async def run_planning_stage(row_data_item: Dict[str, Any], config: Dict[str, An
                 task_type='planning'
             )
 
-        row_data_item['initial_plan'] = json.loads(ai_response)
-        row_data_item['status'] = 'PLAN_GENERATED'
+        new_item["initial_plan"] = json.loads(ai_response)
+        new_item["status"] = "PLAN_GENERATED"
     except Exception as e:
         logger.error(f"Planning stage failed: {e}")
-        row_data_item['status'] = 'PLAN_FAILED'
-        row_data_item['error'] = str(e)
+        new_item["status"] = "PLAN_FAILED"
+        new_item["error"] = str(e)
 
-    return row_data_item
+    return new_item

--- a/tests/test_workflow_integration.py
+++ b/tests/test_workflow_integration.py
@@ -1,0 +1,68 @@
+import unittest
+import asyncio
+import sys
+import os
+from unittest.mock import patch
+
+# setup paths similar to other tests
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+paths = [os.path.join(root_dir, 'showup_tools'), root_dir]
+for p in paths:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from showup_tools.workflow import process_row_for_phase
+
+class TestWorkflowIntegration(unittest.TestCase):
+    def test_full_sequence(self):
+        row = {
+            "Module": "M1",
+            "Lesson": "L1",
+            "Step number": "1",
+            "Step title": "S",
+            "Content Outline": "outline",
+        }
+        result = {"log_entries": []}
+        item = {
+            "row_index": 0,
+            "row": row,
+            "variables": {},
+            "template": "",
+            "context": {},
+            "result": result,
+            "add_log_entry": lambda *a, **k: None,
+        }
+        csv_rows = [row]
+        ui = {}
+
+        def fake_plan(d, cfg):
+            nd = d.copy()
+            nd["initial_plan"] = {"plan": "p"}
+            nd["status"] = "PLAN_GENERATED"
+            return nd
+
+        def fake_refine(d, cfg):
+            nd = d.copy()
+            nd["final_plan"] = {"plan": "fp"}
+            nd["status"] = "PLAN_FINALIZED"
+            return nd
+
+        with patch("showup_tools.workflow.run_planning_stage", side_effect=fake_plan), \
+             patch("showup_tools.workflow.run_refinement_stage", side_effect=fake_refine), \
+             patch("showup_tools.workflow.generate_three_versions_from_plan", return_value=["a", "b", "c"]), \
+             patch("showup_tools.workflow.compare_and_combine", return_value=("best", "exp")), \
+             patch("showup_tools.workflow.review_content", return_value=("reviewed", "sum")), \
+             patch("showup_tools.workflow.run_ai_detection_stage", return_value=[{"pattern": "x"}]), \
+             patch("showup_tools.workflow.save_as_markdown", return_value="out.md"):
+            phases = ["plan", "refine", "generate", "compare", "review", "finalize"]
+            for ph in phases:
+                item = asyncio.run(
+                    process_row_for_phase(item, ph, csv_rows, ".", "profile", "id", ui)
+                )
+
+        self.assertEqual(item["status"], "WORKFLOW_COMPLETE")
+        self.assertEqual(item["final_content_path"], "out.md")
+        self.assertEqual(item["ai_detection_flags"], [{"pattern": "x"}])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow override of prompt paths and copy row data in planning/refinement stages
- expose planning/refinement functions and new ai detection to workflow
- add planning and refinement phases to workflow and finalize using AI detection
- add regression test covering new workflow sequence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68720ccceec48326a0a08db37a91ca02