### PR TITLE
Fix AI phrase path loading

### DIFF
--- a/data/ai_phrases.json
+++ b/data/ai_phrases.json
@@ -1,0 +1,6 @@
+{
+    "patterns": [
+        {"category": "test", "patterns": ["foo"]}
+    ],
+    "phrases": ["bar"]
+}

--- a/showup_tools/ai_detector.py
+++ b/showup_tools/ai_detector.py
@@ -233,8 +233,10 @@ def _load_ai_phrases() -> Dict[str, Any]:
     logger.info("Loading AI phrases")
 
     try:
-        # Path to AI phrases JSON file
-        file_path = "C:\\Users\\User\\Desktop\\ShowupSquaredV4 (2)\\ShowupSquaredV4\\ShowupSquaredV4\\data\\ai_phrases.json"
+        # Path to AI phrases JSON file relative to repository root
+        file_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "data", "ai_phrases.json")
+        )
 
         if not os.path.exists(file_path):
             logger.warning(f"AI phrases file not found: {file_path}")

--- a/tests/test_load_ai_phrases.py
+++ b/tests/test_load_ai_phrases.py
@@ -1,0 +1,25 @@
+import unittest
+import os
+import sys
+import json
+
+# setup import path
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+paths = [os.path.join(root_dir, "showup_tools"), root_dir]
+for p in paths:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from showup_tools.ai_detector import _load_ai_phrases
+
+class TestLoadAIPhrases(unittest.TestCase):
+    def test_load_ai_phrases_repo_relative(self):
+        data = _load_ai_phrases()
+        self.assertIsInstance(data, dict)
+        self.assertIn("phrases", data)
+        self.assertIn("patterns", data)
+        # data/ai_phrases.json created for tests contains 'bar'
+        self.assertIn("bar", data.get("phrases", []))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- load `ai_phrases.json` using a repository-relative path
- add minimal `data/ai_phrases.json` for tests
- test loading of AI phrases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873513738108326bef4654f619f59be