### PR TITLE
Add learner context to planning stage

### DIFF
--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -40,14 +40,33 @@ async def run_planning_stage(
     content_outline = new_item.get("Content Outline") or new_item.get(
         "content_outline", ""
     )
+    learner_profile = new_item.get("Learner Profile") or new_item.get(
+        "learner_profile", ""
+    )
+    rationale = new_item.get("What is the rationale for this step") or new_item.get(
+        "rationale", ""
+    )
+    word_count = str(
+        new_item.get("word_count")
+        or config.get("word_count")
+        or ""
+    )
     if use_dynamic:
         block_defs = get_block_type_definitions()
         prompt = (
             prompt_template.replace("{{content_outline}}", content_outline)
+            .replace("{{learner_profile}}", learner_profile)
+            .replace("{{rationale}}", rationale)
+            .replace("{{word_count}}", word_count)
             .replace("{{block_library}}", block_defs)
         )
     else:
-        prompt = prompt_template.replace("{{content_outline}}", content_outline)
+        prompt = (
+            prompt_template.replace("{{content_outline}}", content_outline)
+            .replace("{{learner_profile}}", learner_profile)
+            .replace("{{rationale}}", rationale)
+            .replace("{{word_count}}", word_count)
+        )
 
     model_id = config.get('model_id', 'claude-3-haiku-20240307')
     provider = get_model_provider(model_id)

--- a/showup_tools/prompts/planning_prompt.txt
+++ b/showup_tools/prompts/planning_prompt.txt
@@ -3,6 +3,14 @@ content blocks from the library below.
 Block Library:
 {{block_library}}
 
+Learner Profile:
+{{learner_profile}}
+
+Rationale:
+{{rationale}}
+
+Target Word Count: {{word_count}}
+
 Guidelines:
 - Start with one `lesson_metadata` block and end with `key_takeaways`.
 - Other blocks may be repeated as needed to cover the outline.

--- a/tests/test_planning_stage.py
+++ b/tests/test_planning_stage.py
@@ -21,7 +21,12 @@ from showup_tools.planning_stage import run_planning_stage
 
 class TestPlanningStage(unittest.TestCase):
     def test_planning_with_claude(self):
-        row = {"content_outline": "Outline"}
+        row = {
+            "content_outline": "Outline",
+            "learner_profile": "Profile",
+            "rationale": "Because",
+            "word_count": 123,
+        }
         config = {"model_id": "claude-3-haiku-20240307"}
         good_plan = {
             "content_blocks": [
@@ -31,12 +36,22 @@ class TestPlanningStage(unittest.TestCase):
         with patch('showup_tools.planning_stage.generate_with_claude') as mock_claude:
             mock_claude.return_value = json.dumps(good_plan)
             result = asyncio.run(run_planning_stage(row, config))
+            called_prompt = mock_claude.call_args.args[0]
+        self.assertIn("Outline", called_prompt)
+        self.assertIn("Profile", called_prompt)
+        self.assertIn("Because", called_prompt)
+        self.assertIn("123", called_prompt)
         self.assertEqual(result['status'], 'PLAN_GENERATED')
         self.assertEqual(result['initial_plan'], good_plan)
         mock_claude.assert_called()
 
     def test_planning_with_openai(self):
-        row = {"content_outline": "Outline"}
+        row = {
+            "content_outline": "Outline",
+            "learner_profile": "Profile",
+            "rationale": "Because",
+            "word_count": 123,
+        }
         config = {"model_id": "gpt-4", "openai_api_key": "x"}
 
         mock_resp = MagicMock()
@@ -53,13 +68,23 @@ class TestPlanningStage(unittest.TestCase):
             client = mock_openai.return_value
             client.chat.completions.create.return_value = mock_resp
             result = asyncio.run(run_planning_stage(row, config))
+            called_prompt = client.chat.completions.create.call_args.kwargs['messages'][0]['content']
+        self.assertIn("Outline", called_prompt)
+        self.assertIn("Profile", called_prompt)
+        self.assertIn("Because", called_prompt)
+        self.assertIn("123", called_prompt)
 
         self.assertEqual(result['status'], 'PLAN_GENERATED')
         self.assertEqual(result['initial_plan'], good_plan)
         mock_openai.assert_called()
 
     def test_planning_validation_error(self):
-        row = {"content_outline": "Outline"}
+        row = {
+            "content_outline": "Outline",
+            "learner_profile": "Profile",
+            "rationale": "Because",
+            "word_count": 123,
+        }
         config = {"model_id": "claude-3-haiku-20240307"}
         with patch('showup_tools.planning_stage.generate_with_claude') as mock_claude:
             mock_claude.return_value = '{"bad": true}'
@@ -68,7 +93,12 @@ class TestPlanningStage(unittest.TestCase):
         self.assertIn('bad', result.get('error', ''))
 
     def test_planning_legacy(self):
-        row = {"content_outline": "Outline"}
+        row = {
+            "content_outline": "Outline",
+            "learner_profile": "Profile",
+            "rationale": "Because",
+            "word_count": 123,
+        }
         config = {"model_id": "claude-3-haiku-20240307", "use_dynamic_blocks": False}
         legacy_plan = {"video_title": "t", "scenes": []}
         with patch('showup_tools.planning_stage.generate_with_claude') as mock_claude:


### PR DESCRIPTION
## Summary
- include learner profile, rationale and word count in planning prompt
- update planning prompt template with placeholders
- verify prompt content in planning stage tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68735124321c832680bcc644b6d22d50