### PR TITLE
Add image placeholder instruction and test

### DIFF
--- a/dev_docs/template Block Definitions.md
+++ b/dev_docs/template Block Definitions.md
@@ -296,6 +296,31 @@
 {
   "block_type": "diagram_placeholder",
   "concept_to_illustrate": "The cyclical nature of motivation",
+---
+
+**13\. `image_placeholder`**
+
+* **Purpose:** Marks a generic image to break up long sections of text.
+* **Key Components/Attributes:**
+  * `type: "image_placeholder"`
+  * `description: str` (Brief description of the image or visual)
+  * `caption: Optional[str]` (Suggested caption for the image)
+  * `placement_suggestion: Optional[str]` (Where the image might appear, e.g., "after the third paragraph")
+* **Placement Guidelines:** Use after 2–3 explanatory blocks or around every ~300 words to improve readability.
+* **Example Usage:**
+  JSON
+
+```json
+{
+  "block_type": "image_placeholder",
+  "description": "A relevant photo or graphic to break up text",
+  "placement_suggestion": "after the third paragraph"
+}
+```
+
+*
+* **Notes:** These blocks provide visual rest points and do not need to depict a specific concept.
+
   "description": "A diagram showing motivation as a cycle: Initial Excitement -> Motivation Dip (challenges) -> Stable Engagement -> Renewal. Include arrows indicating progression.",
   "caption": "Figure 1: The Cyclical Nature of Motivation",
   "placement_suggestion": "after 'Understanding Motivation Cycles' section"

--- a/showup_core/data/logs/workflow2/core.log
+++ b/showup_core/data/logs/workflow2/core.log
@@ -4,3 +4,7 @@
 2025-07-11 10:32:39,648 - core - INFO - Initializing ShowupSquared core module
 2025-07-11 10:44:32,057 - core - INFO - Initializing ShowupSquared core module
 2025-07-11 10:23:11,851 - core - INFO - Initializing ShowupSquared core module
+2025-07-13 07:34:31,280 - core - INFO - Initializing ShowupSquared core module
+2025-07-13 07:34:31,281 - core - WARNING - Could not import HTML converter modules: No module named 'showup_core.html_converter'
+2025-07-13 07:34:31,282 - core - WARNING - Could not import utility functions: No module named 'cache_utils'
+2025-07-13 07:34:31,283 - core - INFO - Initializing ShowupSquared core module

--- a/showup_tools/block_library.py
+++ b/showup_tools/block_library.py
@@ -90,6 +90,13 @@ BLOCK_LIBRARY = {
             "placement_suggestion": "Optional[str]",
         }
     },
+    "image_placeholder": {
+        "fields": {
+            "description": "str",
+            "caption": "Optional[str]",
+            "placement_suggestion": "Optional[str]",
+        }
+    },
 }
 
 

--- a/showup_tools/learning_sections.py
+++ b/showup_tools/learning_sections.py
@@ -1,0 +1,39 @@
+import os
+import logging
+from typing import Tuple
+from .showup_core.api_client import generate_with_claude
+
+logger = logging.getLogger(__name__)
+
+PROMPT_PATH = os.path.join(os.path.dirname(__file__), 'prompts', 'lo_kt_generation_prompt.txt')
+
+async def generate_lo_and_kt_from_content(content: str, model: str = 'claude-3-haiku-20240307', max_tokens: int = 800) -> Tuple[str, str]:
+    """Generate learning objectives and key takeaways from lesson content."""
+    try:
+        with open(PROMPT_PATH, 'r', encoding='utf-8') as f:
+            prompt_template = f.read()
+    except FileNotFoundError as e:
+        logger.error(f'Prompt file not found: {PROMPT_PATH}')
+        raise
+
+    prompt = prompt_template.replace('{{content}}', content)
+    response = await generate_with_claude(
+        prompt=prompt,
+        system_prompt='You are a veteran curriculum designer generating concise learning objectives and key takeaways.',
+        max_tokens=max_tokens,
+        temperature=0.3,
+        model=model,
+        task_type='learning_summaries'
+    )
+    return parse_lo_and_kt(response)
+
+def parse_lo_and_kt(text: str) -> Tuple[str, str]:
+    lo_marker = '## Learning Objectives'
+    kt_marker = '## Key Takeaways'
+    lo_start = text.find(lo_marker)
+    kt_start = text.find(kt_marker)
+    if lo_start == -1 or kt_start == -1:
+        raise ValueError('Could not parse learning sections')
+    lo_section = text[lo_start:kt_start].strip()
+    kt_section = text[kt_start:].strip()
+    return lo_section, kt_section

--- a/showup_tools/markdown_utils.py
+++ b/showup_tools/markdown_utils.py
@@ -1,0 +1,19 @@
+import re
+
+
+def insert_sections_in_markdown(content: str, section: str, position: str = "end") -> str:
+    """Insert markdown `section` into `content` at the specified position."""
+    if position == "after_intro":
+        # Find the first heading (H1 or H2)
+        match = re.search(r"^#{1,2} .*$", content, flags=re.MULTILINE)
+        if match:
+            insert_pos = match.end()
+            # advance past any following blank lines
+            after = re.search(r"\n\s*\n", content[insert_pos:])
+            if after:
+                insert_pos += after.end()
+        else:
+            insert_pos = 0
+        return content[:insert_pos].rstrip() + "\n\n" + section.strip() + "\n\n" + content[insert_pos:].lstrip()
+    else:
+        return content.rstrip() + "\n\n" + section.strip() + "\n"

--- a/showup_tools/prompts/lo_kt_generation_prompt.txt
+++ b/showup_tools/prompts/lo_kt_generation_prompt.txt
@@ -1,0 +1,21 @@
+SYSTEM: You are a veteran curriculum designer. You will read a lesson and extract its learning goals and summary points.
+
+USER:
+"""
+<Lesson Content in Markdown>
+"""
+
+Tasks:
+1. **Learning Objectives:** Write 1-3 bullet-point objectives that describe what a learner will be able to do after this lesson. Use SMART criteria – be Specific, Measurable, Achievable, Relevant, and (if applicable) Time-bound. Start each objective with a strong action verb (e.g. *explain, analyze, create*). Ensure the objectives cover the key skills/knowledge from the lesson content.
+2. **Key Takeaways:** Write 2-4 bullet-point key takeaways that summarize the most important points or insights from the lesson. These should be the crucial facts or concepts a student should remember. Use clear, concise language.
+
+Format the output in Markdown with the following sections:
+
+## Learning Objectives
+- Objective 1...
+- Objective 2...
+
+## Key Takeaways
+- Takeaway 1...
+- Takeaway 2...
+

--- a/showup_tools/prompts/plan_refine_prompt.txt
+++ b/showup_tools/prompts/plan_refine_prompt.txt
@@ -1,4 +1,4 @@
-You are an expert instructional designer. Using the learner profile and critique, improve the initial plan. Use only block types from the library and ensure the plan begins with `lesson_metadata` and ends with `key_takeaways`.
+You are an expert instructional designer. Using the learner profile and critique, improve the initial plan. Use only block types from the library. Ensure the plan begins with `lesson_metadata`, includes `image_placeholder` blocks to break up long text, and omit `learning_objectives` and `key_takeaways` blocks (they will be added later).
 
 Block Library:
 {{block_library}}

--- a/showup_tools/prompts/planning_prompt.txt
+++ b/showup_tools/prompts/planning_prompt.txt
@@ -12,7 +12,11 @@ Rationale:
 Target Word Count: {{word_count}}
 
 Guidelines:
-- Start with one `lesson_metadata` block and end with `key_takeaways`.
+- Start with one `lesson_metadata` block.
+- Include occasional `image_placeholder` blocks to break up long stretches of text. Aim to insert one roughly after every 2–3 `explanatory_text` blocks or about every 300 words.
+- These visuals do not need to illustrate a specific concept; their purpose is to provide a rest for the reader's eyes.
+- Ensure no more than three text-heavy blocks appear in a row without a `diagram_placeholder` or generic `image_placeholder`.
+- Do NOT include `learning_objectives` or `key_takeaways` blocks; these will be added automatically later.
 - Other blocks may be repeated as needed to cover the outline.
 
 Outline:

--- a/showup_tools/workflow.py
+++ b/showup_tools/workflow.py
@@ -23,6 +23,8 @@ from .content_reviewer import review_content
 from .ai_detector import run_ai_detection_stage
 from .planning_stage import run_planning_stage
 from .refinement_stage import run_refinement_stage
+from .learning_sections import generate_lo_and_kt_from_content
+from .markdown_utils import insert_sections_in_markdown
 from .constants import EXCEL_CLARIFICATION
 from showup_core.api_client import generate_with_claude
 # Import RAG system components
@@ -643,6 +645,18 @@ async def process_row_for_phase(row_data_item: Dict[str, Any], phase: str, csv_r
                     return row_data_item
             
             reviewed_content = row_data_item["reviewed_content"]
+
+            try:
+                lo_sec, kt_sec = await generate_lo_and_kt_from_content(
+                    reviewed_content,
+                    model=ui_settings.get("selected_model", "claude-3-haiku-20240307"),
+                )
+                reviewed_content = insert_sections_in_markdown(reviewed_content, lo_sec, position="after_intro")
+                reviewed_content = insert_sections_in_markdown(reviewed_content, kt_sec, position="end")
+                row_data_item["reviewed_content"] = reviewed_content
+                logger.info("Inserted Learning Objectives and Key Takeaways into content")
+            except Exception as e:
+                logger.error(f"LO/KT generation failed: {e}")
 
             add_log_entry("AI Detection", "started", "Scanning content for AI patterns")
             ai_patterns_path = ui_settings.get("ai_patterns_path")

--- a/tests/test_learning_sections.py
+++ b/tests/test_learning_sections.py
@@ -1,0 +1,34 @@
+import unittest
+import asyncio
+import sys
+import os
+from unittest.mock import patch, mock_open
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+paths = [os.path.join(root_dir, 'showup_tools'), root_dir]
+for p in paths:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from showup_tools.markdown_utils import insert_sections_in_markdown
+from showup_tools.learning_sections import generate_lo_and_kt_from_content
+
+class TestLearningSections(unittest.TestCase):
+    def test_insert_after_intro(self):
+        content = "# Title\n\n## Introduction\nIntro text\n\n## Body\nMore"
+        section = "## Learning Objectives\n- Obj"
+        result = insert_sections_in_markdown(content, section, position='after_intro')
+        self.assertIn(section, result)
+        self.assertTrue(result.index(section) < result.index('## Body'))
+
+    def test_generate_learning_sections(self):
+        prompt = "Prompt {{content}}"
+        with patch('builtins.open', mock_open(read_data=prompt)):
+            with patch('showup_tools.learning_sections.generate_with_claude') as mock_gen:
+                mock_gen.return_value = "## Learning Objectives\n- O\n## Key Takeaways\n- K"
+                lo, kt = asyncio.run(generate_lo_and_kt_from_content('x', model='m'))
+        self.assertEqual(lo, "## Learning Objectives\n- O")
+        self.assertEqual(kt, "## Key Takeaways\n- K")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_planning_stage.py
+++ b/tests/test_planning_stage.py
@@ -108,5 +108,25 @@ class TestPlanningStage(unittest.TestCase):
         self.assertEqual(result['status'], 'PLAN_GENERATED')
         self.assertEqual(result['initial_plan'], legacy_plan)
 
+    def test_planning_accepts_image_placeholder(self):
+        row = {
+            "content_outline": "Outline",
+            "learner_profile": "Profile",
+            "rationale": "Because",
+            "word_count": 123,
+        }
+        config = {"model_id": "claude-3-haiku-20240307"}
+        plan = {
+            "content_blocks": [
+                {"block_type": "lesson_metadata", "title": "t", "module_id": "m"},
+                {"block_type": "image_placeholder", "description": "A break"},
+            ]
+        }
+        with patch('showup_tools.planning_stage.generate_with_claude') as mock_claude:
+            mock_claude.return_value = json.dumps(plan)
+            result = asyncio.run(run_planning_stage(row, config))
+        self.assertEqual(result['status'], 'PLAN_GENERATED')
+        self.assertEqual(result['initial_plan'], plan)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_workflow_integration.py
+++ b/tests/test_workflow_integration.py
@@ -53,6 +53,7 @@ class TestWorkflowIntegration(unittest.TestCase):
              patch("showup_tools.workflow.compare_and_combine", return_value=("best", "exp")), \
              patch("showup_tools.workflow.review_content", return_value=("reviewed", "sum")), \
              patch("showup_tools.workflow.run_ai_detection_stage", return_value=[{"pattern": "x"}]), \
+             patch("showup_tools.workflow.generate_lo_and_kt_from_content", return_value=("LO", "KT")), \
              patch("showup_tools.workflow.save_as_markdown", return_value="out.md"):
             phases = ["plan", "refine", "generate", "compare", "review", "finalize"]
             for ph in phases:
@@ -103,6 +104,7 @@ class TestWorkflowIntegration(unittest.TestCase):
              patch("showup_tools.workflow.compare_and_combine", return_value=("best", "exp")), \
              patch("showup_tools.workflow.review_content", return_value=("reviewed", "sum")), \
              patch("showup_tools.workflow.run_ai_detection_stage", return_value=[{"pattern": "x"}]), \
+             patch("showup_tools.workflow.generate_lo_and_kt_from_content", return_value=("LO", "KT")), \
              patch("showup_tools.workflow.save_as_markdown", return_value="out.md"):
             phases = ["plan", "refine", "generate", "compare", "review", "finalize"]
             for ph in phases:


### PR DESCRIPTION
## Summary
- refine planning prompt with clearer instructions for generic image breaks
- introduce dedicated LO/KT generation prompt and hook workflow to it
- implement helper for inserting generated LO/KT sections
- remove unused old LO/KT prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68735b0f640c832681535e1ade9d558f