### PR TITLE
Add additional settings fields to Kivy UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,16 +11,24 @@ from kivy.properties import ObjectProperty, StringProperty, NumericProperty
 from kivy.clock import Clock
 from kivy.lang import Builder
 import os
+import pandas as pd
 
 kivy.require('2.0.0')
 
 class WorkflowAppLayout(BoxLayout):
     """Main layout for the Workflow Application."""
     csv_path_input = ObjectProperty(None)
+    handbook_checkbox = ObjectProperty(None)
+    handbook_path_input = ObjectProperty(None)
+    output_dir_input = ObjectProperty(None)
+    save_to_input = ObjectProperty(None)
+    learner_profile_preview = ObjectProperty(None)
     status_label = ObjectProperty(None)
     progress_bar = ObjectProperty(None)
     output_display = ObjectProperty(None)
     file_chooser_popup = ObjectProperty(None)
+    _directory_target = ObjectProperty(None, allownone=True)
+    config = ObjectProperty(None)
 
     current_stage_name = StringProperty("Idle")
     current_progress_value = NumericProperty(0)
@@ -39,10 +47,28 @@ class WorkflowAppLayout(BoxLayout):
         ]
         self.current_stage_index = 0
         self.mock_workflow_event = None
+        self.config = {}
 
     def show_file_chooser(self):
         """Opens a file chooser popup to select a CSV file."""
         self.file_chooser_popup = FileChooserPopup(self)
+        self.add_widget(self.file_chooser_popup)
+
+    def show_handbook_chooser(self):
+        """Open a popup to select the student handbook file."""
+        self.file_chooser_popup = HandbookChooserPopup(self)
+        self.add_widget(self.file_chooser_popup)
+
+    def show_output_dir_chooser(self):
+        """Open a popup to select the output directory."""
+        self._directory_target = self.output_dir_input
+        self.file_chooser_popup = DirectoryChooserPopup(self)
+        self.add_widget(self.file_chooser_popup)
+
+    def show_save_to_chooser(self):
+        """Open a popup to select directory for generated content."""
+        self._directory_target = self.save_to_input
+        self.file_chooser_popup = DirectoryChooserPopup(self)
         self.add_widget(self.file_chooser_popup)
 
     def select_csv_file(self, path, filename):
@@ -50,15 +76,53 @@ class WorkflowAppLayout(BoxLayout):
         if filename and filename[0].endswith('.csv'):
             full_path = os.path.join(path, filename[0])
             self.csv_path_input.text = full_path
-            self.remove_widget(self.file_chooser_popup)
-            self.file_chooser_popup = None
+            self.load_learner_profile(full_path)
+            if self.file_chooser_popup:
+                self.remove_widget(self.file_chooser_popup)
+                self.file_chooser_popup = None
         else:
             self.status_label.text = "Please select a .csv file."
 
+    def select_handbook_file(self, path, filename):
+        """Callback to set the selected handbook file."""
+        if filename:
+            full_path = os.path.join(path, filename[0])
+            self.handbook_path_input.text = full_path
+            if self.file_chooser_popup:
+                self.remove_widget(self.file_chooser_popup)
+                self.file_chooser_popup = None
+        else:
+            self.status_label.text = "Please select a file."
+
+    def select_directory(self, selection):
+        """Callback to set the selected directory."""
+        if selection:
+            self._directory_target.text = selection[0]
+            if self.file_chooser_popup:
+                self.remove_widget(self.file_chooser_popup)
+                self.file_chooser_popup = None
+            self._directory_target = None
+        else:
+            self.status_label.text = "Please select a directory."
+
     def cancel_file_chooser(self):
         """Cancels the file chooser popup."""
-        self.remove_widget(self.file_chooser_popup)
-        self.file_chooser_popup = None
+        if self.file_chooser_popup:
+            self.remove_widget(self.file_chooser_popup)
+            self.file_chooser_popup = None
+
+    def load_learner_profile(self, csv_path: str):
+        """Load the learner profile from the first row of the CSV, if present."""
+        try:
+            df = pd.read_csv(csv_path)
+        except Exception as exc:
+            self.status_label.text = f"Failed to read CSV: {exc}"
+            return
+        if 'learner_profile' in df.columns and not df['learner_profile'].isna().all():
+            profile = df['learner_profile'].dropna().iloc[0]
+            self.learner_profile_preview.text = str(profile)
+        else:
+            self.learner_profile_preview.text = ""
 
     def start_workflow(self):
         """Simulates starting the content generation workflow."""
@@ -71,6 +135,15 @@ class WorkflowAppLayout(BoxLayout):
         self.current_progress_value = 0
         self.output_display.text = ""
         self.status_label.text = "Workflow started..."
+
+        self.config = {
+            "csv_path": csv_file,
+            "handbook_path": self.handbook_path_input.text,
+            "use_handbook": bool(self.handbook_checkbox.active),
+            "output_dir": self.output_dir_input.text,
+            "save_to": self.save_to_input.text,
+            "learner_profile": self.learner_profile_preview.text,
+        }
 
         if self.mock_workflow_event:
             self.mock_workflow_event.cancel()
@@ -158,6 +231,16 @@ class FileChooserPopup(BoxLayout):
     def __init__(self, caller, **kwargs):
         super().__init__(**kwargs)
         self.caller = caller
+
+
+class HandbookChooserPopup(FileChooserPopup):
+    """Popup for selecting a handbook file."""
+    pass
+
+
+class DirectoryChooserPopup(FileChooserPopup):
+    """Popup for selecting a directory."""
+    pass
 
 class WorkflowApp(App):
     """The main Kivy application class."""

--- a/tests/test_kivy_app.py
+++ b/tests/test_kivy_app.py
@@ -15,6 +15,23 @@ class TestWorkflowApp(unittest.TestCase):
         app = WorkflowApp()
         root_widget = app.build()
         self.assertIsNotNone(root_widget.csv_path_input)
+        self.assertIsNotNone(root_widget.handbook_checkbox)
+        self.assertIsNotNone(root_widget.handbook_path_input)
+        self.assertIsNotNone(root_widget.output_dir_input)
+        self.assertIsNotNone(root_widget.save_to_input)
+        self.assertIsNotNone(root_widget.learner_profile_preview)
+
+    def test_select_csv_updates_profile(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "sample.csv")
+            with open(csv_path, "w", encoding="utf-8") as f:
+                f.write("learner_profile\nProfile text")
+            app = WorkflowApp()
+            root_widget = app.build()
+            root_widget.select_csv_file(tmpdir, ["sample.csv"])
+            self.assertEqual(root_widget.learner_profile_preview.text, "Profile text")
 
 if __name__ == '__main__':
     unittest.main()

--- a/workflow_app.kv
+++ b/workflow_app.kv
@@ -2,6 +2,11 @@
 
 <WorkflowAppLayout>:
     csv_path_input: _csv_path_input
+    handbook_checkbox: _handbook_checkbox
+    handbook_path_input: _handbook_path_input
+    output_dir_input: _output_dir_input
+    save_to_input: _save_to_input
+    learner_profile_preview: _learner_profile_preview
     status_label: _status_label
     progress_bar: _progress_bar
     output_display: _output_display
@@ -116,6 +121,145 @@
                 background_color: 0.3, 0.3, 0.3, 1
                 foreground_color: 0.2, 0.7, 0.3, 1
 
+            Label:
+                text: "Student Handbook Integration"
+                size_hint_y: None
+                height: '30dp'
+                font_size: '18sp'
+                bold: True
+                color: 0.8, 0.8, 0.8, 1
+
+            BoxLayout:
+                orientation: 'horizontal'
+                size_hint_y: None
+                height: '30dp'
+                spacing: 10
+                CheckBox:
+                    id: _handbook_checkbox
+                    size_hint_x: None
+                    width: '30dp'
+                    color: 0.2, 0.7, 0.3, 1
+                Label:
+                    text: "Pull relevant information from student handbook before generation."
+                    text_size: self.width, None
+                    halign: 'left'
+                    valign: 'middle'
+                    color: 0.9, 0.9, 0.9, 1
+
+            BoxLayout:
+                orientation: 'horizontal'
+                size_hint_y: None
+                height: '40dp'
+                spacing: 10
+                TextInput:
+                    id: _handbook_path_input
+                    hint_text: "Student Handbook File"
+                    multiline: False
+                    readonly: True
+                    background_color: 0.3, 0.3, 0.3, 1
+                    foreground_color: 0.9, 0.9, 0.9, 1
+                    cursor_color: 0.9, 0.9, 0.9, 1
+                    font_size: '14sp'
+                    padding: [10, 10]
+                    border: [8,8,8,8]
+                    radius: [5,]
+                Button:
+                    text: "Browse..."
+                    size_hint_x: None
+                    width: '90dp'
+                    background_normal: ''
+                    background_color: 0.1, 0.5, 0.7, 1
+                    color: 1, 1, 1, 1
+                    font_size: '14sp'
+                    radius: [8,]
+                    on_release: root.show_handbook_chooser()
+
+            Label:
+                text: "Output Settings"
+                size_hint_y: None
+                height: '30dp'
+                font_size: '18sp'
+                bold: True
+                color: 0.8, 0.8, 0.8, 1
+
+            BoxLayout:
+                orientation: 'horizontal'
+                size_hint_y: None
+                height: '40dp'
+                spacing: 10
+                TextInput:
+                    id: _output_dir_input
+                    hint_text: "Output Directory"
+                    multiline: False
+                    readonly: True
+                    background_color: 0.3, 0.3, 0.3, 1
+                    foreground_color: 0.9, 0.9, 0.9, 1
+                    cursor_color: 0.9, 0.9, 0.9, 1
+                    font_size: '14sp'
+                    padding: [10, 10]
+                    border: [8,8,8,8]
+                    radius: [5,]
+                Button:
+                    text: "Browse..."
+                    size_hint_x: None
+                    width: '90dp'
+                    background_normal: ''
+                    background_color: 0.1, 0.5, 0.7, 1
+                    color: 1, 1, 1, 1
+                    font_size: '14sp'
+                    radius: [8,]
+                    on_release: root.show_output_dir_chooser()
+
+            BoxLayout:
+                orientation: 'horizontal'
+                size_hint_y: None
+                height: '40dp'
+                spacing: 10
+                TextInput:
+                    id: _save_to_input
+                    hint_text: "Save Generated Content To"
+                    multiline: False
+                    readonly: True
+                    background_color: 0.3, 0.3, 0.3, 1
+                    foreground_color: 0.9, 0.9, 0.9, 1
+                    cursor_color: 0.9, 0.9, 0.9, 1
+                    font_size: '14sp'
+                    padding: [10, 10]
+                    border: [8,8,8,8]
+                    radius: [5,]
+                Button:
+                    text: "Browse..."
+                    size_hint_x: None
+                    width: '90dp'
+                    background_normal: ''
+                    background_color: 0.1, 0.5, 0.7, 1
+                    color: 1, 1, 1, 1
+                    font_size: '14sp'
+                    radius: [8,]
+                    on_release: root.show_save_to_chooser()
+
+            Label:
+                text: "Learner Profile Preview"
+                size_hint_y: None
+                height: '30dp'
+                font_size: '18sp'
+                bold: True
+                color: 0.8, 0.8, 0.8, 1
+
+            TextInput:
+                id: _learner_profile_preview
+                text: ''
+                readonly: True
+                size_hint_y: None
+                height: '100dp'
+                background_color: 0.3, 0.3, 0.3, 1
+                foreground_color: 0.9, 0.9, 0.9, 1
+                font_size: '14sp'
+                padding: [10, 10]
+                cursor_color: 0.9, 0.9, 0.9, 1
+                border: [8,8,8,8]
+                radius: [5,]
+
             Widget:
                 size_hint_y: 1
 
@@ -220,6 +364,66 @@
         Button:
             text: "Select"
             on_release: root.caller.select_csv_file(file_chooser.path, file_chooser.selection)
+            background_normal: ''
+            background_color: 0.2, 0.7, 0.3, 1
+            color: 1, 1, 1, 1
+            font_size: '16sp'
+            bold: True
+            radius: [8,]
+        Button:
+            text: "Cancel"
+            on_release: root.caller.cancel_file_chooser()
+            background_normal: ''
+            background_color: 0.7, 0.2, 0.2, 1
+            color: 1, 1, 1, 1
+            font_size: '16sp'
+            bold: True
+            radius: [8,]
+
+<HandbookChooserPopup@FileChooserPopup>:
+    FileChooserListView:
+        id: file_chooser
+        filters: ['*.pdf', '*.md', '*.txt']
+        path: App.get_running_app().user_data_dir
+        on_submit: root.caller.select_handbook_file(self.path, self.selection)
+
+    BoxLayout:
+        size_hint_y: None
+        height: '48dp'
+        spacing: 10
+        Button:
+            text: "Select"
+            on_release: root.caller.select_handbook_file(file_chooser.path, file_chooser.selection)
+            background_normal: ''
+            background_color: 0.2, 0.7, 0.3, 1
+            color: 1, 1, 1, 1
+            font_size: '16sp'
+            bold: True
+            radius: [8,]
+        Button:
+            text: "Cancel"
+            on_release: root.caller.cancel_file_chooser()
+            background_normal: ''
+            background_color: 0.7, 0.2, 0.2, 1
+            color: 1, 1, 1, 1
+            font_size: '16sp'
+            bold: True
+            radius: [8,]
+
+<DirectoryChooserPopup@FileChooserPopup>:
+    FileChooserListView:
+        id: file_chooser
+        dirselect: True
+        path: App.get_running_app().user_data_dir
+        on_submit: root.caller.select_directory(self.selection)
+
+    BoxLayout:
+        size_hint_y: None
+        height: '48dp'
+        spacing: 10
+        Button:
+            text: "Select"
+            on_release: root.caller.select_directory(file_chooser.selection)
             background_normal: ''
             background_color: 0.2, 0.7, 0.3, 1
             color: 1, 1, 1, 1


### PR DESCRIPTION
## Summary
- expose new UI widgets for handbook, output dirs, and learner profile preview
- wire widgets to `WorkflowAppLayout` object properties
- add directory and handbook choosers
- display learner profile after CSV load
- test new UI field logic

## Testing
- `pytest -q tests/test_kivy_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6873666104388326a2454dbff30abcb1