### PR TITLE
Fix file chooser path

### DIFF
--- a/tests/test_kivy_app.py
+++ b/tests/test_kivy_app.py
@@ -33,5 +33,12 @@ class TestWorkflowApp(unittest.TestCase):
             root_widget.select_csv_file(tmpdir, ["sample.csv"])
             self.assertEqual(root_widget.learner_profile_preview.text, "Profile text")
 
+    def test_file_chooser_uses_app_user_data_dir(self):
+        app = WorkflowApp()
+        root_widget = app.build()
+        root_widget.show_file_chooser()
+        chooser_path = root_widget.file_chooser_popup.ids.file_chooser.path
+        self.assertEqual(chooser_path, app.user_data_dir)
+
 if __name__ == '__main__':
     unittest.main()

--- a/workflow_app.kv
+++ b/workflow_app.kv
@@ -354,7 +354,7 @@
     FileChooserListView:
         id: file_chooser
         filters: ['*.csv']
-        path: App.get_running_app().user_data_dir
+        path: app.user_data_dir
         on_submit: root.caller.select_csv_file(self.path, self.selection)
 
     BoxLayout:
@@ -384,7 +384,7 @@
     FileChooserListView:
         id: file_chooser
         filters: ['*.pdf', '*.md', '*.txt']
-        path: App.get_running_app().user_data_dir
+        path: app.user_data_dir
         on_submit: root.caller.select_handbook_file(self.path, self.selection)
 
     BoxLayout:
@@ -414,7 +414,7 @@
     FileChooserListView:
         id: file_chooser
         dirselect: True
-        path: App.get_running_app().user_data_dir
+        path: app.user_data_dir
         on_submit: root.caller.select_directory(self.selection)
 
     BoxLayout:


### PR DESCRIPTION
## Summary
- point FileChooser popup path to `app.user_data_dir`
- add a unit test verifying the popup uses the app's data dir

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68736fc8d2288326800b144f4b500518