### PR TITLE
Fix workflow import path handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,15 @@
 import kivy
 kivy.require('2.3.1')  # Ensure minimum Kivy version
 
+import sys
+import os
+
+# --- CRITICAL FIX: Add project root to sys.path before any local imports ---
+project_root = os.path.abspath(os.path.dirname(__file__))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+# --- END OF CRITICAL FIX ---
+
 from kivy.app import App
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.label import Label
@@ -15,7 +24,6 @@ from kivy.properties import StringProperty, BooleanProperty, NumericProperty
 import asyncio
 import threading
 import queue
-import os
 import json
 import logging
 import datetime

--- a/showup_tools/workflow.py
+++ b/showup_tools/workflow.py
@@ -6,15 +6,6 @@ This module orchestrates the entire workflow, from reading the CSV file to savin
 
 import logging
 import os
-import sys
-
-# --- START OF CRITICAL FIX ---
-# Add the project root to the Python path to allow direct import of showup_core
-# This assumes showup_tools is directly in the project root, and showup_core is also at the root.
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if project_root not in sys.path:
-    sys.path.insert(0, project_root)
-# --- END OF CRITICAL FIX ---
 
 import datetime
 import asyncio

--- a/tests/test_workflow_core_import.py
+++ b/tests/test_workflow_core_import.py
@@ -1,4 +1,6 @@
 import importlib
+import importlib.machinery
+import importlib.util
 import sys
 import shutil
 import types
@@ -52,28 +54,38 @@ def clear_stubs():
             sys.modules.pop(k, None)
 
 
-def test_import_adds_project_root(tmp_path):
+def test_main_adds_project_root(tmp_path):
     root, tools_dir = setup_temp_environment(tmp_path)
+    main_src = Path(__file__).resolve().parents[1] / 'main.py'
+    shutil.copy2(main_src, root / 'main.py')
+
     if str(root) in sys.path:
         sys.path.remove(str(root))
+
     orig_workflow = sys.modules.get('showup_tools.workflow')
     for k in list(sys.modules.keys()):
-        if k.startswith('showup_tools') or k.startswith('showup_core'):
+        if k.startswith('showup_tools') or k.startswith('showup_core') or k == 'main':
             sys.modules.pop(k, None)
+
     add_stubs()
-    sys.path.insert(0, str(tools_dir.parent))
+
+    loader = importlib.machinery.SourceFileLoader('main', str(root / 'main.py'))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    main_module = importlib.util.module_from_spec(spec)
+    loader.exec_module(main_module)
+
     try:
-        wf = importlib.import_module('showup_tools.workflow')
         assert str(root) in sys.path
+        wf = importlib.import_module('showup_tools.workflow')
         assert wf.generate_with_claude() == 'ok'
     finally:
-        sys.path.remove(str(tools_dir.parent))
         if str(root) in sys.path:
             sys.path.remove(str(root))
         clear_stubs()
         sys.modules.pop('showup_tools.workflow', None)
         if orig_workflow is not None:
             sys.modules['showup_tools.workflow'] = orig_workflow
+        sys.modules.pop('main', None)
         sys.modules.pop('showup_tools', None)
         sys.modules.pop('showup_core', None)
         sys.modules.pop('showup_core.api_client', None)


### PR DESCRIPTION
## Summary
- remove path patching from `workflow.py`
- ensure `main.py` updates `sys.path` before local imports
- adapt workflow core import test for new path setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873a2382c008326b7029078ce030ea4