### PR TITLE
Reconnect GUI to full workflow

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,11 +29,11 @@ import logging
 import datetime
 import traceback
 
-# Import the simplified workflow implementation
+# Import the full workflow implementation with planning and refinement
 try:
-    from simplified_workflow.workflow import run_workflow, setup_logging
+    from showup_tools.workflow import run_workflow, setup_logging
 except ImportError as e:
-    logging.error(f"Failed to import simplified workflow module: {e}")
+    logging.error(f"Failed to import workflow module: {e}")
     run_workflow = None
     setup_logging = None
 
@@ -47,7 +47,7 @@ class WorkflowApp(App):
     output_info = StringProperty("")
 
     def build(self):
-        self.title = "ShowUp AI Content Generation (Simplified Workflow)"
+        self.title = "ShowUp AI Content Generation"
 
         main_layout = BoxLayout(orientation='vertical', padding=10, spacing=10)
         input_grid = BoxLayout(orientation='vertical', size_hint_y=None, height=300, spacing=5)

--- a/tests/test_kivy_app.py
+++ b/tests/test_kivy_app.py
@@ -15,13 +15,13 @@ from main import WorkflowApp
 
 class TestWorkflowApp(unittest.TestCase):
     def setUp(self):
-        dummy_pkg = types.ModuleType('simplified_workflow')
-        dummy_mod = types.ModuleType('simplified_workflow.workflow')
+        dummy_pkg = types.ModuleType('showup_tools')
+        dummy_mod = types.ModuleType('showup_tools.workflow')
 
         def dummy_run_workflow(*a, **k):
             return {'status': 'ok'}
 
-        dummy_run_workflow.__module__ = 'simplified_workflow.workflow'
+        dummy_run_workflow.__module__ = 'showup_tools.workflow'
 
         def dummy_setup_logging(*a, **k):
             return 'test.log'
@@ -30,15 +30,15 @@ class TestWorkflowApp(unittest.TestCase):
         dummy_mod.setup_logging = dummy_setup_logging
         dummy_pkg.run_workflow = dummy_run_workflow
         dummy_pkg.setup_logging = dummy_setup_logging
-        sys.modules['simplified_workflow'] = dummy_pkg
-        sys.modules['simplified_workflow.workflow'] = dummy_mod
+        sys.modules['showup_tools'] = dummy_pkg
+        sys.modules['showup_tools.workflow'] = dummy_mod
 
         self.app = WorkflowApp()
         self.root_widget = self.app.build()
 
     def tearDown(self):
-        sys.modules.pop('simplified_workflow', None)
-        sys.modules.pop('simplified_workflow.workflow', None)
+        sys.modules.pop('showup_tools', None)
+        sys.modules.pop('showup_tools.workflow', None)
 
     def test_build_has_inputs(self):
         self.assertIsNotNone(self.app.csv_path_input)
@@ -59,15 +59,15 @@ class TestWorkflowApp(unittest.TestCase):
         self.assertEqual(self.app.progress_value, 25)
         self.assertIn('25%', self.app.status_message)
 
-    def test_start_workflow_invokes_simplified_run(self):
+    def test_start_workflow_invokes_workflow_run(self):
         self.app.csv_path_input.text = 'data/sample_input.csv'
         self.app.handbook_path_input.text = ''
         self.app.course_name_input.text = 'Course'
         self.app.learner_profile_input.text = 'Learner'
 
-        # ensure the imported run_workflow comes from simplified_workflow
+        # ensure the imported run_workflow comes from showup_tools
         import main
-        self.assertEqual(main.run_workflow.__module__, 'simplified_workflow.workflow')
+        self.assertEqual(main.run_workflow.__module__, 'showup_tools.workflow')
 
         class DummyThread:
             def __init__(self, target, args):

--- a/tests/test_workflow_core_import.py
+++ b/tests/test_workflow_core_import.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 def setup_temp_environment(tmp_path: Path):
     root = tmp_path / "project_root"
-    simplified_dir = root / "simplified_workflow"
+    simplified_dir = root / "showup_tools"
     simplified_dir.mkdir(parents=True)
     (simplified_dir / "__init__.py").write_text("from .workflow import run_workflow, setup_logging\n")
     (simplified_dir / "workflow.py").write_text(
@@ -35,7 +35,7 @@ def test_main_adds_project_root(tmp_path):
     if str(root) in sys.path:
         sys.path.remove(str(root))
 
-    orig_workflow = sys.modules.get('simplified_workflow.workflow')
+    orig_workflow = sys.modules.get('showup_tools.workflow')
     for k in list(sys.modules.keys()):
         if k.startswith('showup_tools') or k.startswith('showup_core') or k == 'main':
             sys.modules.pop(k, None)
@@ -49,14 +49,14 @@ def test_main_adds_project_root(tmp_path):
 
     try:
         assert str(root) in sys.path
-        wf = importlib.import_module('simplified_workflow.workflow')
+        wf = importlib.import_module('showup_tools.workflow')
         assert wf.run_workflow() == {'status': 'ok'}
     finally:
         if str(root) in sys.path:
             sys.path.remove(str(root))
         clear_stubs()
-        sys.modules.pop('simplified_workflow.workflow', None)
+        sys.modules.pop('showup_tools.workflow', None)
         if orig_workflow is not None:
-            sys.modules['simplified_workflow.workflow'] = orig_workflow
+            sys.modules['showup_tools.workflow'] = orig_workflow
         sys.modules.pop('main', None)
 


### PR DESCRIPTION
## Summary
- wire Kivy `main.py` to the original workflow implementation
- adjust GUI title
- update tests to expect `showup_tools.workflow`

## Testing
- `pytest tests/test_planning_stage.py tests/test_refinement_stage.py tests/test_reference_handbook_config.py tests/test_workflow_integration.py`
- `pytest -q` *(fails: RuntimeError in integration tests)*

------
https://chatgpt.com/codex/tasks/task_b_6873cba2ae408326bc46fe52ae9a92c6