### PR TITLE
Clean up unused imports

### DIFF
--- a/showup_core/__init__.py
+++ b/showup_core/__init__.py
@@ -86,34 +86,6 @@ try:
 except ImportError as e:
     core_logger.warning(f"Could not import API client functions: {e}")
 
-# Try to import HTML utilities
-try:
-    from showup_core.html_converter import (
-        process_html_metadata,
-        create_html_base,
-        process_html_section,
-        convert_markdown_to_html,
-        convert_lesson_to_html,
-        convert_module_to_html,
-        generate_content_html,
-        generate_enhancement_comparison_report,
-        HTMLConverter
-    )
-    
-    # Add to public API
-    __all__.extend([
-        'process_html_metadata',
-        'create_html_base',
-        'process_html_section',
-        'convert_markdown_to_html',
-        'convert_lesson_to_html',
-        'convert_module_to_html',
-        'generate_content_html',
-        'generate_enhancement_comparison_report',
-        'HTMLConverter'
-    ])
-except ImportError as e:
-    core_logger.warning(f"Could not import HTML converter modules: {e}")
 
 # Try to import content enhancer modules
 try:

--- a/showup_core/utils.py
+++ b/showup_core/utils.py
@@ -10,7 +10,6 @@ import logging
 from typing import Any, List
 
 import claude_api
-import cache_utils
 
 logger = logging.getLogger("utils")
 


### PR DESCRIPTION
## Summary
- remove deprecated HTML converter imports and __all__ entries
- drop unused `cache_utils` import in utils

## Testing
- `pytest -q` *(fails: TestReferenceHandbookConfig::test_new_config_keys_trigger_handbook_extraction, TestWorkflowIntegration::test_full_sequence, TestWorkflowIntegration::test_full_sequence_legacy)*

------
https://chatgpt.com/codex/tasks/task_b_6873d07a3e148326a476796017f2187c