### PR TITLE
Remove legacy refinement mode

### DIFF
--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 PROMPTS_DIR = os.path.join(os.path.dirname(__file__), "prompts")
 PLANNING_PROMPT_PATH = os.path.join(PROMPTS_DIR, "planning_prompt.txt")
-LEGACY_PLANNING_PROMPT_PATH = os.path.join(PROMPTS_DIR, "planning_prompt_legacy.txt")
 
 async def run_planning_stage(
     row_data_item: Dict[str, Any], config: Dict[str, Any]
@@ -22,10 +21,9 @@ async def run_planning_stage(
 
     new_item = row_data_item.copy()
 
-    use_dynamic = config.get("use_dynamic_blocks", True)
     prompt_path = config.get(
         "planning_prompt_path",
-        PLANNING_PROMPT_PATH if use_dynamic else LEGACY_PLANNING_PROMPT_PATH,
+        PLANNING_PROMPT_PATH,
     )
 
     try:
@@ -51,22 +49,14 @@ async def run_planning_stage(
         or config.get("word_count")
         or ""
     )
-    if use_dynamic:
-        block_defs = get_block_type_definitions()
-        prompt = (
-            prompt_template.replace("{{content_outline}}", content_outline)
-            .replace("{{learner_profile}}", learner_profile)
-            .replace("{{rationale}}", rationale)
-            .replace("{{word_count}}", word_count)
-            .replace("{{block_library}}", block_defs)
-        )
-    else:
-        prompt = (
-            prompt_template.replace("{{content_outline}}", content_outline)
-            .replace("{{learner_profile}}", learner_profile)
-            .replace("{{rationale}}", rationale)
-            .replace("{{word_count}}", word_count)
-        )
+    block_defs = get_block_type_definitions()
+    prompt = (
+        prompt_template.replace("{{content_outline}}", content_outline)
+        .replace("{{learner_profile}}", learner_profile)
+        .replace("{{rationale}}", rationale)
+        .replace("{{word_count}}", word_count)
+        .replace("{{block_library}}", block_defs)
+    )
 
     model_id = config.get('model_id', 'claude-3-haiku-20240307')
     provider = get_model_provider(model_id)
@@ -91,10 +81,7 @@ async def run_planning_stage(
                 task_type='planning'
             )
 
-        if use_dynamic:
-            new_item["initial_plan"] = validate_plan(ai_response).model_dump(exclude_none=True)
-        else:
-            new_item["initial_plan"] = json.loads(ai_response)
+        new_item["initial_plan"] = validate_plan(ai_response).model_dump(exclude_none=True)
         new_item["status"] = "PLAN_GENERATED"
     except Exception as e:
         logger.error(f"Planning stage failed: {e}")

--- a/showup_tools/refinement_stage.py
+++ b/showup_tools/refinement_stage.py
@@ -12,8 +12,6 @@ logger = logging.getLogger(__name__)
 PROMPTS_DIR = os.path.join(os.path.dirname(__file__), 'prompts')
 CRITIQUE_PROMPT_PATH = os.path.join(PROMPTS_DIR, "plan_critique_prompt.txt")
 REFINE_PROMPT_PATH = os.path.join(PROMPTS_DIR, "plan_refine_prompt.txt")
-LEGACY_CRITIQUE_PROMPT_PATH = os.path.join(PROMPTS_DIR, "plan_critique_prompt_legacy.txt")
-LEGACY_REFINE_PROMPT_PATH = os.path.join(PROMPTS_DIR, "plan_refine_prompt_legacy.txt")
 
 async def run_refinement_stage(
     row_data_item: Dict[str, Any], config: Dict[str, Any]
@@ -23,15 +21,13 @@ async def run_refinement_stage(
 
     new_item = row_data_item.copy()
 
-    use_dynamic = config.get("use_dynamic_blocks", True)
-
     critique_path = config.get(
         "critique_prompt_path",
-        CRITIQUE_PROMPT_PATH if use_dynamic else LEGACY_CRITIQUE_PROMPT_PATH,
+        CRITIQUE_PROMPT_PATH,
     )
     refine_path = config.get(
         "refine_prompt_path",
-        REFINE_PROMPT_PATH if use_dynamic else LEGACY_REFINE_PROMPT_PATH,
+        REFINE_PROMPT_PATH,
     )
 
     try:
@@ -51,15 +47,11 @@ async def run_refinement_stage(
     initial_plan_obj = new_item.get("initial_plan", {})
     initial_plan_str = json.dumps(initial_plan_obj, ensure_ascii=False)
 
-    if use_dynamic:
-        block_defs = get_block_type_definitions()
-    else:
-        block_defs = None
+    block_defs = get_block_type_definitions()
 
     critique_prompt = critique_template.replace('{{learner_profile}}', learner_profile)
     critique_prompt = critique_prompt.replace('{{initial_plan}}', initial_plan_str)
-    if block_defs is not None:
-        critique_prompt = critique_prompt.replace('{{block_library}}', block_defs)
+    critique_prompt = critique_prompt.replace('{{block_library}}', block_defs)
 
     model_id = config.get('model_id', 'claude-3-haiku-20240307')
     provider = get_model_provider(model_id)
@@ -88,8 +80,7 @@ async def run_refinement_stage(
         refine_prompt = refine_template.replace('{{learner_profile}}', learner_profile)
         refine_prompt = refine_prompt.replace('{{initial_plan}}', initial_plan_str)
         refine_prompt = refine_prompt.replace('{{critique}}', critique)
-        if block_defs is not None:
-            refine_prompt = refine_prompt.replace('{{block_library}}', block_defs)
+        refine_prompt = refine_prompt.replace('{{block_library}}', block_defs)
 
         if provider == 'openai':
             response2 = client.chat.completions.create(
@@ -108,10 +99,7 @@ async def run_refinement_stage(
                 task_type='plan_refine'
             )
 
-        if use_dynamic:
-            new_item["final_plan"] = validate_plan(revised_plan_text).model_dump(exclude_none=True)
-        else:
-            new_item["final_plan"] = json.loads(revised_plan_text)
+        new_item["final_plan"] = validate_plan(revised_plan_text).model_dump(exclude_none=True)
         new_item["status"] = "PLAN_FINALIZED"
     except Exception as e:
         logger.error(f"Refinement stage failed: {e}")

--- a/tests/test_planning_stage.py
+++ b/tests/test_planning_stage.py
@@ -92,22 +92,6 @@ class TestPlanningStage(unittest.TestCase):
         self.assertEqual(result['status'], 'PLAN_FAILED')
         self.assertIn('bad', result.get('error', ''))
 
-    def test_planning_legacy(self):
-        row = {
-            "content_outline": "Outline",
-            "learner_profile": "Profile",
-            "rationale": "Because",
-            "word_count": 123,
-        }
-        config = {"model_id": "claude-3-haiku-20240307", "use_dynamic_blocks": False}
-        legacy_plan = {"video_title": "t", "scenes": []}
-        with patch('showup_tools.planning_stage.generate_with_claude') as mock_claude:
-            mock_claude.return_value = json.dumps(legacy_plan)
-            with patch('builtins.open', mock_open(read_data='prompt')):
-                result = asyncio.run(run_planning_stage(row, config))
-        self.assertEqual(result['status'], 'PLAN_GENERATED')
-        self.assertEqual(result['initial_plan'], legacy_plan)
-
     def test_planning_accepts_image_placeholder(self):
         row = {
             "content_outline": "Outline",

--- a/tests/test_refinement_stage.py
+++ b/tests/test_refinement_stage.py
@@ -1,10 +1,9 @@
 import unittest
 import asyncio
-import importlib
 import sys
 import os
 import json
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock
 
 # setup paths similar to other tests
 root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -66,16 +65,6 @@ class TestRefinementStage(unittest.TestCase):
         self.assertEqual(result['status'], 'PLAN_FAILED')
         self.assertIn('bad', result.get('error', ''))
 
-    def test_refinement_legacy(self):
-        legacy_plan = {"video_title": "t", "scenes": []}
-        row = {"initial_plan": legacy_plan, "learner_profile": "profile"}
-        config = {"model_id": "claude-3-haiku-20240307", "use_dynamic_blocks": False}
-        with patch('showup_tools.refinement_stage.generate_with_claude') as mock_claude:
-            mock_claude.side_effect = ['critique', json.dumps(legacy_plan)]
-            with patch('builtins.open', side_effect=[mock_open(read_data='c').return_value, mock_open(read_data='r').return_value]):
-                result = asyncio.run(run_refinement_stage(row, config))
-        self.assertEqual(result['status'], 'PLAN_FINALIZED')
-        self.assertEqual(result['final_plan'], legacy_plan)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- drop `use_dynamic_blocks` check from refinement stage
- simplify prompt replacement logic
- validate refined plan every time
- remove outdated refinement legacy test

## Testing
- `pytest tests/test_planning_stage.py tests/test_workflow_integration.py tests/test_generation_stage.py tests/test_refinement_stage.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6873e178c2bc8326ac2693d644f3290b