### PR TITLE
Switch to OS dialog for file selection

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,8 +15,7 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.label import Label
 from kivy.uix.textinput import TextInput
 from kivy.uix.button import Button
-from kivy.uix.filechooser import FileChooserListView
-from kivy.uix.popup import Popup
+from tkinter import Tk, filedialog
 from kivy.uix.progressbar import ProgressBar
 from kivy.clock import Clock
 from kivy.properties import StringProperty, BooleanProperty, NumericProperty
@@ -107,18 +106,14 @@ class WorkflowApp(App):
         self.start_button.disabled = value or (run_workflow is None)
 
     def show_file_chooser(self, target_text_input, file_type):
-        file_chooser = FileChooserListView(path=os.getcwd())
-
-        def select_file(instance, value):
-            if value:
-                target_text_input.text = value[0]
-            popup.dismiss()
-
-        file_chooser.bind(on_submit=select_file)
-        file_chooser.bind(on_select=select_file)
-
-        popup = Popup(title=f"Select {file_type.capitalize()} File", content=file_chooser, size_hint=(0.9, 0.9))
-        popup.open()
+        root = Tk()
+        root.withdraw()
+        try:
+            path = filedialog.askopenfilename()
+        finally:
+            root.destroy()
+        if path:
+            target_text_input.text = path
 
     def start_workflow(self, instance):
         if self.workflow_running:

--- a/tests/test_kivy_app.py
+++ b/tests/test_kivy_app.py
@@ -66,6 +66,17 @@ class TestWorkflowApp(unittest.TestCase):
         self.assertEqual(self.app.progress_value, 25)
         self.assertIn('25%', self.app.status_message)
 
+    def test_show_file_chooser_sets_text(self):
+        with unittest.mock.patch('main.filedialog.askopenfilename', return_value='/tmp/file.csv'):
+            class DummyTk:
+                def withdraw(self):
+                    pass
+                def destroy(self):
+                    pass
+            with unittest.mock.patch('main.Tk', return_value=DummyTk()):
+                self.app.show_file_chooser(self.app.csv_path_input, 'csv')
+        self.assertEqual(self.app.csv_path_input.text, '/tmp/file.csv')
+
     def test_start_workflow_invokes_workflow_run(self):
         self.app.csv_path_input.text = 'data/sample_input.csv'
         self.app.handbook_path_input.text = ''


### PR DESCRIPTION
## Summary
- use `tkinter.filedialog` in `show_file_chooser`
- update imports for `Tk` and `filedialog`
- test that the path chosen from the OS dialog populates the field

## Testing
- `pytest tests/test_logging.py tests/test_kivy_app.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6873e534517c832695fad8bf760d8e2c