### PR TITLE
Switch Kivy file chooser to OS dialog

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,8 +15,8 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.label import Label
 from kivy.uix.textinput import TextInput
 from kivy.uix.button import Button
-from kivy.uix.filechooser import FileChooserListView
-from kivy.uix.popup import Popup
+import tkinter as tk
+from tkinter import filedialog
 from kivy.uix.progressbar import ProgressBar
 from kivy.clock import Clock
 from kivy.properties import StringProperty, BooleanProperty, NumericProperty
@@ -107,18 +107,20 @@ class WorkflowApp(App):
         self.start_button.disabled = value or (run_workflow is None)
 
     def show_file_chooser(self, target_text_input, file_type):
-        file_chooser = FileChooserListView(path=os.getcwd())
-
-        def select_file(instance, selection, touch=None):
-            if selection:
-                target_text_input.text = selection[0]
-            popup.dismiss()
-
-        file_chooser.bind(on_submit=select_file)
-        file_chooser.bind(on_select=select_file)
-
-        popup = Popup(title=f"Select {file_type.capitalize()} File", content=file_chooser, size_hint=(0.9, 0.9))
-        popup.open()
+        """Open an OS file dialog and set the selected path."""
+        root = None
+        try:
+            root = tk.Tk()
+            root.withdraw()
+        except tk.TclError:
+            root = None
+        try:
+            file_path = filedialog.askopenfilename(title=f"Select {file_type.capitalize()} File")
+        finally:
+            if root is not None:
+                root.destroy()
+        if file_path:
+            target_text_input.text = file_path
 
     def start_workflow(self, instance):
         if self.workflow_running:

--- a/tests/test_kivy_app.py
+++ b/tests/test_kivy_app.py
@@ -15,8 +15,27 @@ import types
 kivy_stub_path = os.path.join(os.path.dirname(__file__), 'kivy_stub')
 if kivy_stub_path not in sys.path:
     sys.path.insert(0, kivy_stub_path)
+
 import kivy_stub
 sys.modules['kivy'] = kivy_stub
+
+dummy_pkg = types.ModuleType('showup_tools')
+dummy_mod = types.ModuleType('showup_tools.workflow')
+
+def dummy_run_workflow(*a, **k):
+    return {'status': 'ok'}
+
+dummy_run_workflow.__module__ = 'showup_tools.workflow'
+
+def dummy_setup_logging(*a, **k):
+    return 'test.log'
+
+dummy_mod.run_workflow = dummy_run_workflow
+dummy_mod.setup_logging = dummy_setup_logging
+dummy_pkg.run_workflow = dummy_run_workflow
+dummy_pkg.setup_logging = dummy_setup_logging
+sys.modules['showup_tools'] = dummy_pkg
+sys.modules['showup_tools.workflow'] = dummy_mod
 
 from main import WorkflowApp
 
@@ -88,6 +107,13 @@ class TestWorkflowApp(unittest.TestCase):
             with unittest.mock.patch.object(self.app, 'run_workflow_in_thread') as mock_run:
                 self.app.start_workflow(None)
                 mock_run.assert_called_once()
+
+    def test_show_file_chooser_sets_text(self):
+        self.app.csv_path_input.text = ''
+        with unittest.mock.patch('tkinter.filedialog.askopenfilename', return_value='/tmp/test.csv') as mock_dialog:
+            self.app.show_file_chooser(self.app.csv_path_input, 'csv')
+            mock_dialog.assert_called_once()
+        self.assertEqual(self.app.csv_path_input.text, '/tmp/test.csv')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- replace Kivy `FileChooserListView` with `tkinter.filedialog.askopenfilename`
- import Tkinter filedialog and update test harness
- add unit test to verify the selected path populates the text field

## Testing
- `pytest tests/test_kivy_app.py -q`
- `pytest tests/test_kivy_app.py::TestWorkflowApp::test_show_file_chooser_sets_text -q`

------
https://chatgpt.com/codex/tasks/task_b_6873e648c1d88326becdc9f775006193