### PR TITLE
Normalize package discovery and remove path hacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,16 @@ This project is under active development. Several features are recent additions 
 * **Module Stubs and Archive:** The repository’s `archive/` folder contains older versions of modules (e.g., early `workflow.py.bak` files) and scripts that are no longer active. If you encounter references to the `simplified_app` or `simplified_workflow` modules, note that these were part of a previous iteration using a Tkinter GUI (`showup_tools/simplified_app.py`)[GitHub](https://github.com/helloshowup/hope-clean/blob/4fccb1237fdb87e687769a0337dcec36ddc92ed0/showup_tools/simplified_app.py#L64-L73)[GitHub](https://github.com/helloshowup/hope-clean/blob/4fccb1237fdb87e687769a0337dcec36ddc92ed0/showup_tools/simplified_app.py#L66-L74). The current direction is to consolidate everything into the main application pipeline. Be cautious of any lingering references or stub functions that might still exist but are not fully integrated.
 
 By keeping these points in mind, a new developer can navigate the codebase more effectively. The **focus** of this README is to map out the end-to-end flow of how a piece of educational content goes from a row in a CSV to a polished lesson file with objectives and more. As development continues, this document should be updated to reflect the implementation status of each feature. Feel free to cross-reference the code modules cited above to dive deeper into each stage of the workflow. Happy coding, and welcome to the ShowUp content generation project\!
+
+## Repository Structure and Import Strategy
+
+To ensure a clean, maintainable, and robust codebase, the project uses standard Python packaging practices. All modules are automatically discovered without any manual `sys.path` tweaks or custom import hooks.
+
+**Key Principles:**
+
+* **Standardized Package Naming**: All package directories follow normal Python naming conventions (e.g., `showup_core` instead of `showup-core`). Import statements match these directory names directly.
+* **Automatic Package Discovery**: `pyproject.toml` is configured so that `setuptools` automatically finds all packages within the repository. This simplifies installation and testing.
+* **No Manual Path Adjustments**: Legacy helpers that added entries to `sys.path` or used custom path finders have been removed. The standard Python import mechanism is relied upon exclusively.
+
+Developers should follow these conventions whenever adding new modules so that imports remain consistent and reliable.
+

--- a/main.py
+++ b/main.py
@@ -4,12 +4,6 @@ kivy.require('2.3.1')  # Ensure minimum Kivy version
 import sys
 import os
 
-# --- CRITICAL FIX: Add project root to sys.path before any local imports ---
-project_root = os.path.abspath(os.path.dirname(__file__))
-if project_root not in sys.path:
-    sys.path.insert(0, project_root)
-# --- END OF CRITICAL FIX ---
-
 from kivy.app import App
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.label import Label

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,4 @@ dev = [
 
 [tool.setuptools.packages.find]
 where = ["."]
-exclude = ["tests", "dev_docs"]
+include = ["showup_core*", "showup_tools*", "simplified_workflow*", "showup_editor_ui*"]

--- a/tests/test_ai_detection_stage.py
+++ b/tests/test_ai_detection_stage.py
@@ -4,13 +4,6 @@ import sys
 import os
 from unittest.mock import patch, mock_open
 
-# setup paths similar to other tests
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-paths = [os.path.join(root_dir, "showup_tools"), root_dir]
-for p in paths:
-    if p not in sys.path:
-        sys.path.insert(0, p)
-
 if "showup_core" in sys.modules:
     del sys.modules["showup_core"]
 

--- a/tests/test_generation_stage.py
+++ b/tests/test_generation_stage.py
@@ -6,13 +6,6 @@ import sys
 import os
 from unittest.mock import patch, mock_open
 
-# setup paths similar to other tests
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-paths = [os.path.join(root_dir, 'showup_tools'), root_dir]
-for p in paths:
-    if p not in sys.path:
-        sys.path.insert(0, p)
-
 # remove stale namespace packages that may block imports
 if 'showup_core' in sys.modules:
     del sys.modules['showup_core']

--- a/tests/test_kivy_app.py
+++ b/tests/test_kivy_app.py
@@ -3,10 +3,6 @@ import unittest.mock
 import os
 import sys
 
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if root_dir not in sys.path:
-    sys.path.insert(0, root_dir)
-
 os.environ['KIVY_NO_ARGS'] = '1'
 
 import types
@@ -19,25 +15,16 @@ if kivy_stub_path not in sys.path:
 import kivy_stub
 sys.modules['kivy'] = kivy_stub
 
-dummy_pkg = types.ModuleType('showup_tools')
-dummy_mod = types.ModuleType('showup_tools.workflow')
 
-def dummy_run_workflow(*a, **k):
-    return {'status': 'ok'}
+import importlib.util
+from pathlib import Path
 
-dummy_run_workflow.__module__ = 'showup_tools.workflow'
-
-def dummy_setup_logging(*a, **k):
-    return 'test.log'
-
-dummy_mod.run_workflow = dummy_run_workflow
-dummy_mod.setup_logging = dummy_setup_logging
-dummy_pkg.run_workflow = dummy_run_workflow
-dummy_pkg.setup_logging = dummy_setup_logging
-sys.modules['showup_tools'] = dummy_pkg
-sys.modules['showup_tools.workflow'] = dummy_mod
-
-from main import WorkflowApp
+main_spec = importlib.util.spec_from_file_location(
+    'main', Path(__file__).resolve().parents[1] / 'main.py'
+)
+main = importlib.util.module_from_spec(main_spec)
+main_spec.loader.exec_module(main)
+WorkflowApp = main.WorkflowApp
 
 class TestWorkflowApp(unittest.TestCase):
     def setUp(self):
@@ -92,7 +79,6 @@ class TestWorkflowApp(unittest.TestCase):
         self.app.learner_profile_input.text = 'Learner'
 
         # ensure the imported run_workflow comes from showup_tools
-        import main
         self.assertEqual(main.run_workflow.__module__, 'showup_tools.workflow')
 
         class DummyThread:

--- a/tests/test_learning_sections.py
+++ b/tests/test_learning_sections.py
@@ -4,12 +4,6 @@ import sys
 import os
 from unittest.mock import patch, mock_open
 
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-paths = [os.path.join(root_dir, 'showup_tools'), root_dir]
-for p in paths:
-    if p not in sys.path:
-        sys.path.insert(0, p)
-
 from simplified_workflow.markdown_utils import insert_sections_in_markdown
 from simplified_workflow.learning_sections import generate_lo_and_kt_from_content
 

--- a/tests/test_load_ai_phrases.py
+++ b/tests/test_load_ai_phrases.py
@@ -3,13 +3,6 @@ import os
 import sys
 import json
 
-# setup import path
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-paths = [os.path.join(root_dir, "showup_tools"), root_dir]
-for p in paths:
-    if p not in sys.path:
-        sys.path.insert(0, p)
-
 from showup_tools.ai_detector import _load_ai_phrases
 
 class TestLoadAIPhrases(unittest.TestCase):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,13 +3,6 @@ import os
 import sys
 import logging
 
-# setup paths similar to other tests
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-paths = [os.path.join(root_dir, "showup_tools"), root_dir]
-for p in paths:
-    if p not in sys.path:
-        sys.path.insert(0, p)
-
 if "showup_core" in sys.modules:
     del sys.modules["showup_core"]
 

--- a/tests/test_planning_stage.py
+++ b/tests/test_planning_stage.py
@@ -6,13 +6,6 @@ import os
 import json
 from unittest.mock import patch, MagicMock, mock_open
 
-# setup paths similar to other tests
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-paths = [os.path.join(root_dir, 'showup_tools'), root_dir]
-for p in paths:
-    if p not in sys.path:
-        sys.path.insert(0, p)
-
 # provide stub for openai if missing
 if 'openai' not in sys.modules:
     sys.modules['openai'] = MagicMock()

--- a/tests/test_rag_dynamic.py
+++ b/tests/test_rag_dynamic.py
@@ -5,12 +5,6 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-paths = [os.path.join(root_dir, 'showup_tools'), root_dir]
-for p in paths:
-    if p not in sys.path:
-        sys.path.insert(0, p)
-
 from simplified_workflow.workflow import extract_student_handbook_information
 
 class TestDynamicRagWorkflow(unittest.TestCase):

--- a/tests/test_rag_integration_import.py
+++ b/tests/test_rag_integration_import.py
@@ -2,10 +2,6 @@ import importlib
 import os
 import sys
 
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if root_dir not in sys.path:
-    sys.path.insert(0, root_dir)
-
 
 def test_enhanced_generate_content_import():
     module = importlib.import_module('simplified_workflow.rag_system.rag_integration')

--- a/tests/test_reference_handbook_config.py
+++ b/tests/test_reference_handbook_config.py
@@ -4,13 +4,6 @@ import sys
 import os
 from unittest.mock import AsyncMock, patch
 
-# setup paths similar to other tests
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-paths = [os.path.join(root_dir, 'showup_tools'), root_dir]
-for p in paths:
-    if p not in sys.path:
-        sys.path.insert(0, p)
-
 from showup_tools.workflow import process_row_for_phase
 
 class TestReferenceHandbookConfig(unittest.TestCase):
@@ -28,7 +21,15 @@ class TestReferenceHandbookConfig(unittest.TestCase):
         ui = {"use_reference_handbook": True, "reference_handbook_path": "handbook.md"}
         async_mock = AsyncMock(return_value="info")
         with patch("os.path.exists", return_value=True), \
-             patch("showup_tools.workflow.extract_student_handbook_information", async_mock):
+             patch("showup_tools.workflow.extract_student_handbook_information", async_mock), \
+             patch("showup_tools.workflow.run_planning_stage", return_value={"status": "PLAN_GENERATED", "initial_plan": {}}), \
+             patch("showup_tools.workflow.run_refinement_stage", return_value={"status": "PLAN_FINALIZED", "final_plan": {}}), \
+             patch("showup_tools.workflow.generate_three_versions_from_plan", return_value=["a", "b", "c"]), \
+             patch("showup_tools.workflow.compare_and_combine", return_value=("best", "exp")), \
+             patch("showup_tools.workflow.review_content", return_value=("reviewed", "sum")), \
+             patch("showup_tools.workflow.run_ai_detection_stage", return_value=[{"pattern": "x"}]), \
+             patch("showup_tools.workflow.generate_lo_and_kt_from_content", return_value=("LO", "KT")), \
+             patch("showup_tools.workflow.save_as_markdown", return_value="out.md"):
             result = asyncio.run(process_row_for_phase(item, "generate", [row], ".", "profile", "id", ui))
         self.assertIn("reference_handbook_info", result["variables"])
         async_mock.assert_awaited_once_with("test outline", "handbook.md", ui)

--- a/tests/test_refinement_stage.py
+++ b/tests/test_refinement_stage.py
@@ -5,13 +5,6 @@ import os
 import json
 from unittest.mock import patch, MagicMock
 
-# setup paths similar to other tests
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-paths = [os.path.join(root_dir, 'showup_tools'), root_dir]
-for p in paths:
-    if p not in sys.path:
-        sys.path.insert(0, p)
-
 # provide stub for openai if missing
 if 'openai' not in sys.modules:
     sys.modules['openai'] = MagicMock()

--- a/tests/test_workflow_core_import.py
+++ b/tests/test_workflow_core_import.py
@@ -88,8 +88,8 @@ def test_main_adds_project_root(tmp_path):
     main_src = Path(__file__).resolve().parents[1] / 'main.py'
     shutil.copy2(main_src, root / 'main.py')
 
-    if str(root) in sys.path:
-        sys.path.remove(str(root))
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
 
     orig_workflow = sys.modules.get('showup_tools.workflow')
     for k in list(sys.modules.keys()):
@@ -104,7 +104,6 @@ def test_main_adds_project_root(tmp_path):
     loader.exec_module(main_module)
 
     try:
-        assert str(root) in sys.path
         wf = importlib.import_module('showup_tools.workflow')
         assert wf.run_workflow() == {'status': 'ok'}
     finally:

--- a/tests/test_workflow_integration.py
+++ b/tests/test_workflow_integration.py
@@ -4,13 +4,6 @@ import sys
 import os
 from unittest.mock import patch
 
-# setup paths similar to other tests
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-paths = [os.path.join(root_dir, 'showup_tools'), root_dir]
-for p in paths:
-    if p not in sys.path:
-        sys.path.insert(0, p)
-
 from showup_tools.workflow import process_row_for_phase
 
 class TestWorkflowIntegration(unittest.TestCase):


### PR DESCRIPTION
## Summary
- document new package import approach in README
- configure `pyproject.toml` for package discovery
- drop manual `sys.path` tweaks and custom import logic from tests and main
- update tests to import modules without path manipulation

## Testing
- `python -m pip install -e .`
- `pytest -q` *(fails: RecursionError in workflow tests)*

------
https://chatgpt.com/codex/tasks/task_b_6873ed17a8ec8326a90ca66d65b0e6f7