### PR TITLE
Fix output area height

### DIFF
--- a/workflow_app.kv
+++ b/workflow_app.kv
@@ -335,7 +335,7 @@
                     foreground_color: 0.9, 0.9, 0.9, 1
                     padding: [10, 10]
                     size_hint_y: None
-                    height: self.minimum_height
+                    height: max(self.minimum_height, dp(200))
                     cursor_color: 0,0,0,0
                     selection_color: 0.1, 0.5, 0.7, 0.5
 


### PR DESCRIPTION
## Summary
- ensure the output display keeps a reasonable size

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'showup_tools')*

------
https://chatgpt.com/codex/tasks/task_b_68746df1772483269e2d30d6b0b39c0b