### PR TITLE
Add max_retries to instructor calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ flake8
 isort
 pydantic>=2
 openai
+instructor
 anthropic
 kivy
 pyinstaller

--- a/showup_tools/__init__.py
+++ b/showup_tools/__init__.py
@@ -1,8 +1,28 @@
 # Initialize the simplified_app package
 from .planning_stage import run_planning_stage
 from .refinement_stage import run_refinement_stage
+from .models import (
+    SentimentAnalysis,
+    DetectedAIPattern,
+    DetectedAIPhrase,
+    TextSegmentAnalysis,
+    GeneratedContentBlock,
+    DynamicContentGenerationResult,
+)
+from .openai_dynamic_generation import (
+    generate_structured_content,
+    repair_generated_json_with_llm,
+)
 
 __all__ = [
     'run_planning_stage',
     'run_refinement_stage',
+    'SentimentAnalysis',
+    'DetectedAIPattern',
+    'DetectedAIPhrase',
+    'TextSegmentAnalysis',
+    'GeneratedContentBlock',
+    'DynamicContentGenerationResult',
+    'generate_structured_content',
+    'repair_generated_json_with_llm',
 ]

--- a/showup_tools/models/__init__.py
+++ b/showup_tools/models/__init__.py
@@ -1,0 +1,17 @@
+from .generation_output import (
+    SentimentAnalysis,
+    DetectedAIPattern,
+    DetectedAIPhrase,
+    TextSegmentAnalysis,
+    GeneratedContentBlock,
+    DynamicContentGenerationResult,
+)
+
+__all__ = [
+    'SentimentAnalysis',
+    'DetectedAIPattern',
+    'DetectedAIPhrase',
+    'TextSegmentAnalysis',
+    'GeneratedContentBlock',
+    'DynamicContentGenerationResult',
+]

--- a/showup_tools/models/generation_output.py
+++ b/showup_tools/models/generation_output.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import List, Literal, Dict, Any, Optional
+from pydantic import BaseModel, Field
+
+class SentimentAnalysis(BaseModel):
+    """Detailed sentiment analysis of text."""
+
+    overall_sentiment: Literal["Positive", "Negative", "Neutral"] = Field(
+        ..., description="The overall sentiment of the text."
+    )
+    score: float = Field(
+        ..., description="A sentiment score from -1.0 (very negative) to 1.0 (very positive)."
+    )
+
+class DetectedAIPattern(BaseModel):
+    """Represents a detected AI pattern category and its matches."""
+
+    category: str = Field(
+        ..., description="The category of the detected AI pattern (e.g., 'Comparisons')."
+    )
+    matches: List[str] = Field(
+        default_factory=list, description="List of specific text snippets that matched the pattern."
+    )
+
+class DetectedAIPhrase(BaseModel):
+    """Represents a specific AI phrase detected in the content."""
+
+    phrase: str = Field(..., description="The specific AI phrase detected.")
+    count: int = Field(..., description="Number of times this phrase was detected.")
+
+class TextSegmentAnalysis(BaseModel):
+    """Consolidated analysis results for a text segment."""
+
+    sentiment: SentimentAnalysis = Field(..., description="Sentiment analysis for this segment.")
+    detected_phrases: List[DetectedAIPhrase] = Field(
+        default_factory=list,
+        description="AI phrases detected in this segment, referencing 'ai_phrases.json'.",
+    )
+    detected_patterns: List[DetectedAIPattern] = Field(
+        default_factory=list,
+        description="AI pattern categories detected in this segment, referencing 'ai_patterns.json'.",
+    )
+
+class GeneratedContentBlock(BaseModel):
+    """Represents a single dynamic content block within the generated output."""
+
+    block_id: str = Field(..., description="A unique identifier for this content block.")
+    block_type: str = Field(..., description="Type of content block (e.g., 'introduction').")
+    title: Optional[str] = Field(None, description="Optional title for the content block.")
+    content: str = Field(..., description="Actual text content of this block.")
+    order: int = Field(..., description="Sequential order of this block within the document.")
+    analysis: Optional[TextSegmentAnalysis] = Field(
+        None, description="Optional analysis results specifically for this content block."
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional metadata specific to this block (e.g., source, generation parameters).",
+    )
+
+class DynamicContentGenerationResult(BaseModel):
+    """Structured output from the dynamic block template generation phase."""
+
+    document_id: str = Field(..., description="Unique identifier for the entire generated document.")
+    document_title: str = Field(..., description="Overall title of the generated document.")
+    generated_blocks: List[GeneratedContentBlock] = Field(
+        ..., description="List of dynamically generated content blocks in order."
+    )
+    overall_summary: str = Field(
+        ..., description="Concise one-paragraph summary of the entire generated document."
+    )
+    overall_sentiment: Optional[SentimentAnalysis] = Field(
+        None, description="Optional overall sentiment analysis for the entire document."
+    )
+    generation_metadata: Dict[str, Any] = Field(
+        default_factory=dict, description="Metadata about the entire generation process."
+    )

--- a/showup_tools/openai_dynamic_generation.py
+++ b/showup_tools/openai_dynamic_generation.py
@@ -1,0 +1,81 @@
+import logging
+import instructor
+from openai import AsyncOpenAI
+from .models import DynamicContentGenerationResult
+
+
+log = logging.getLogger(__name__)
+
+
+def get_instructor_client(api_key: str) -> AsyncOpenAI:
+    """Create an OpenAI client patched with instructor for schema enforcement."""
+    return instructor.from_openai(AsyncOpenAI(api_key=api_key))
+
+
+async def repair_generated_json_with_llm(
+    broken_text: str,
+    api_key: str,
+    model: str = "gpt-4o-mini",
+) -> DynamicContentGenerationResult | None:
+    """Attempt to repair invalid JSON using the LLM itself."""
+    log.info("Attempting to repair generated content JSON with LLM")
+    client = get_instructor_client(api_key)
+    try:
+        return await client.chat.completions.create(
+            model=model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "The following text is malformed JSON that was supposed to conform to the DynamicContentGenerationResult schema. "
+                        "Fix the JSON so it strictly conforms to the schema. Do not add any conversational text, just the corrected JSON."
+                    ),
+                },
+                {"role": "user", "content": broken_text},
+            ],
+            temperature=0.0,
+            response_model=DynamicContentGenerationResult,
+        )
+    except Exception as exc:
+        log.error(f"Repair attempt for generated content failed: {exc}")
+        return None
+
+
+async def generate_structured_content(
+    generation_prompt_text: str,
+    api_key: str,
+    model: str = "gpt-4o-mini",
+    raw_llm_output_snippet: str | None = None,
+) -> DynamicContentGenerationResult | None:
+    """Generate structured dynamic content with schema enforcement and fallback."""
+    client = get_instructor_client(api_key)
+    try:
+        generated_content_result = await client.chat.completions.create(
+            model=model,
+            response_model=DynamicContentGenerationResult,
+            max_retries=2,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "Generate content structured into dynamic blocks based on the user's request. "
+                        "Ensure the output strictly conforms to the DynamicContentGenerationResult JSON schema, "
+                        "including all required fields for blocks and overall document structure."
+                    ),
+                },
+                {"role": "user", "content": generation_prompt_text},
+            ],
+        )
+        return generated_content_result
+    except Exception as exc:
+        log.error(f"Content generation API error during evaluation: {exc}")
+        if raw_llm_output_snippet:
+            repaired_result = await repair_generated_json_with_llm(
+                broken_text=raw_llm_output_snippet,
+                api_key=api_key,
+                model=model,
+            )
+            if repaired_result:
+                log.info("Successfully repaired generated content JSON using LLM fallback.")
+            return repaired_result
+        return None

--- a/tests/test_generation_output_models.py
+++ b/tests/test_generation_output_models.py
@@ -1,0 +1,35 @@
+import unittest
+from showup_tools.models import (
+    SentimentAnalysis,
+    DetectedAIPattern,
+    DetectedAIPhrase,
+    TextSegmentAnalysis,
+    GeneratedContentBlock,
+    DynamicContentGenerationResult,
+)
+
+class TestGenerationOutputModels(unittest.TestCase):
+    def test_dynamic_result_parsing(self):
+        sample = {
+            "document_id": "doc1",
+            "document_title": "Sample Document",
+            "generated_blocks": [
+                {
+                    "block_id": "b1",
+                    "block_type": "introduction",
+                    "title": "Intro",
+                    "content": "Hello world",
+                    "order": 1,
+                    "metadata": {"foo": "bar"}
+                }
+            ],
+            "overall_summary": "Summary text",
+            "generation_metadata": {"model": "test"}
+        }
+
+        result = DynamicContentGenerationResult.model_validate(sample)
+        self.assertEqual(result.document_id, "doc1")
+        self.assertEqual(result.generated_blocks[0].block_type, "introduction")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_openai_instructor.py
+++ b/tests/test_openai_instructor.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from showup_tools.openai_dynamic_generation import (
+    generate_structured_content,
+    repair_generated_json_with_llm,
+)
+from showup_tools.models import DynamicContentGenerationResult
+
+
+class TestOpenAIInstructor(unittest.IsolatedAsyncioTestCase):
+    async def test_generate_structured_content(self):
+        with patch('showup_tools.openai_dynamic_generation.instructor.from_openai') as mock_from_openai, \
+             patch('showup_tools.openai_dynamic_generation.AsyncOpenAI'):
+            mock_client = mock_from_openai.return_value
+            mock_client.chat.completions.create = AsyncMock(return_value='result')
+            result = await generate_structured_content('prompt', api_key='k', model='gpt-test')
+            mock_from_openai.assert_called()
+            mock_client.chat.completions.create.assert_awaited_with(
+                model='gpt-test',
+                response_model=DynamicContentGenerationResult,
+                messages=unittest.mock.ANY,
+                max_retries=2,
+            )
+            self.assertEqual(result, 'result')
+
+    async def test_generate_structured_content_repair_path(self):
+        with patch('showup_tools.openai_dynamic_generation.instructor.from_openai') as mock_from_openai, \
+             patch('showup_tools.openai_dynamic_generation.AsyncOpenAI'), \
+             patch('showup_tools.openai_dynamic_generation.repair_generated_json_with_llm', new=AsyncMock(return_value='fixed')) as mock_repair:
+            mock_client = mock_from_openai.return_value
+            mock_client.chat.completions.create = AsyncMock(side_effect=Exception('fail'))
+            result = await generate_structured_content('prompt', api_key='k', model='gpt-test', raw_llm_output_snippet='{}')
+            mock_repair.assert_awaited_with(broken_text='{}', api_key='k', model='gpt-test')
+            self.assertEqual(result, 'fixed')
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- include automatic retries when generating structured content with instructor
- check the max_retries parameter in the instructor integration test
- add LLM fallback function to repair badly formed JSON results
- retry logic now calls the LLM repair method on failure

## Testing
- Skipped per AGENTS.md instructions

------
https://chatgpt.com/codex/tasks/task_b_6874728ecb088326a8f1b342c6058db4