### PR TITLE
Fix planning stage truncation

### DIFF
--- a/main.py
+++ b/main.py
@@ -157,7 +157,7 @@ class WorkflowApp(App):
             "initial_generation_model": "claude-3-haiku-20240307",
             "planning_model": "claude-3-haiku-20240307",
             "refinement_model": "claude-3-haiku-20240307",
-            "planning_max_tokens": 1000,
+            "planning_max_tokens": 8000,
             "refinement_max_tokens": 1000,
             "planning_temperature": 0.3,
             "refinement_temperature": 0.3,

--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -58,31 +58,40 @@ async def run_planning_stage(
     model_id = config.get('model_id', 'claude-3-haiku-20240307')
     provider = get_model_provider(model_id)
 
-    try:
-        if provider == 'openai':
-            import openai
-            client = openai.OpenAI(api_key=config.get('openai_api_key'))
-            response = client.chat.completions.create(
-                model=model_id,
-                messages=[{"role": "user", "content": prompt}],
-                max_tokens=config.get('max_tokens', 1000),
-                temperature=config.get('temperature', 0.3)
-            )
-            ai_response = response.choices[0].message.content
-        else:
-            ai_response = await generate_with_claude(
-                prompt,
-                max_tokens=config.get('max_tokens', 1000),
-                temperature=config.get('temperature', 0.3),
-                model=model_id,
-                task_type='planning'
-            )
+    max_attempts = config.get("max_attempts", 3)
+    last_error = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            if provider == 'openai':
+                import openai
+                client = openai.OpenAI(api_key=config.get('openai_api_key'))
+                response = client.chat.completions.create(
+                    model=model_id,
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=config.get('max_tokens', 8000),
+                    temperature=config.get('temperature', 0.3)
+                )
+                ai_response = response.choices[0].message.content
+            else:
+                ai_response = await generate_with_claude(
+                    prompt,
+                    max_tokens=config.get('max_tokens', 8000),
+                    temperature=config.get('temperature', 0.3),
+                    model=model_id,
+                    task_type='planning'
+                )
 
-        new_item["initial_plan"] = validate_plan(ai_response).model_dump(exclude_none=True)
-        new_item["status"] = "PLAN_GENERATED"
-    except Exception as e:
-        logger.error(f"Planning stage failed: {e}")
+            new_item["initial_plan"] = validate_plan(ai_response).model_dump(exclude_none=True)
+            new_item["status"] = "PLAN_GENERATED"
+            break
+        except Exception as e:
+            last_error = e
+            logger.error(f"Planning attempt {attempt} failed: {e}")
+            if attempt < max_attempts:
+                await asyncio.sleep(1)
+
+    if new_item.get("status") != "PLAN_GENERATED":
         new_item["status"] = "PLAN_FAILED"
-        new_item["error"] = str(e)
+        new_item["error"] = str(last_error) if last_error else "unknown error"
 
     return new_item

--- a/showup_tools/prompts/planning_prompt.txt
+++ b/showup_tools/prompts/planning_prompt.txt
@@ -19,6 +19,11 @@ Guidelines:
 - Do NOT include `learning_objectives` or `key_takeaways` blocks; these will be added automatically later.
 - Other blocks may be repeated as needed to cover the outline.
 
+Output Requirements:
+- Produce a single, complete JSON object that conforms to the `PlanModel` schema.
+- Use double quotes for all keys and string values.
+- Do not include trailing commas or any text outside the JSON object.
+
 Outline:
 {{content_outline}}
 

--- a/showup_tools/workflow.py
+++ b/showup_tools/workflow.py
@@ -342,7 +342,7 @@ async def process_row_for_phase(row_data_item: Dict[str, Any], phase: str, csv_r
                 "model_id": ui_settings.get(
                     "planning_model", ui_settings.get("selected_model", "claude-3-haiku-20240307")
                 ),
-                "max_tokens": ui_settings.get("planning_max_tokens", 1000),
+                "max_tokens": ui_settings.get("planning_max_tokens", 8000),
                 "temperature": ui_settings.get("planning_temperature", 0.3),
                 "openai_api_key": ui_settings.get("openai_api_key"),
                 "planning_prompt_path": ui_settings.get("planning_prompt_path"),


### PR DESCRIPTION
## Summary
- increase default `planning_max_tokens` to 8000
- add retry logic for planning API calls
- reinforce JSON instructions in planning prompt

## Testing
- `pytest -k planning_stage -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_68747a7ba54c83268e3de6cba3e60136