### PR TITLE
Use sonnet 3.5 as default planning model

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from tkinter import filedialog
 from kivy.uix.progressbar import ProgressBar
 from kivy.clock import Clock
 from kivy.properties import StringProperty, BooleanProperty, NumericProperty
+from showup_core.model_config import DEFAULT_PLANNING_MODEL
 
 import asyncio
 import threading
@@ -155,7 +156,7 @@ class WorkflowApp(App):
             "reference_handbook_path": abs_handbook_path,
             "selected_model": "claude-3-haiku-20240307",
             "initial_generation_model": "claude-3-haiku-20240307",
-            "planning_model": "claude-3-haiku-20240307",
+            "planning_model": DEFAULT_PLANNING_MODEL,
             "refinement_model": "claude-3-haiku-20240307",
             "planning_max_tokens": 8000,
             "refinement_max_tokens": 1000,

--- a/showup_core/api_client.py
+++ b/showup_core/api_client.py
@@ -19,7 +19,11 @@ from pathlib import Path
 def get_project_root() -> Path:
     """Return the project root directory."""
     return Path(__file__).resolve().parents[1]
-from .model_config import DEFAULT_MODEL, DEFAULT_CONTEXT_MODEL
+from .model_config import (
+    DEFAULT_MODEL,
+    DEFAULT_CONTEXT_MODEL,
+    DEFAULT_PLANNING_MODEL,
+)
 
 try:
     from .api_utils import (
@@ -316,8 +320,12 @@ async def generate_with_claude(prompt: str, max_tokens: int = 4000, temperature:
     # Log the start of the AI request
     # Determine default model if not provided
     if not model:
-        if task_type and ("context" in task_type or "summary" in task_type):
-            model = DEFAULT_CONTEXT_MODEL
+        if task_type and (
+            "context" in task_type
+            or "summary" in task_type
+            or "planning" in task_type
+        ):
+            model = DEFAULT_PLANNING_MODEL
         else:
             model = DEFAULT_MODEL
 

--- a/showup_core/model_config.py
+++ b/showup_core/model_config.py
@@ -22,6 +22,9 @@ DEFAULT_MODEL = "claude-3-7-sonnet-20250219"
 # Default model for building context or summaries
 DEFAULT_CONTEXT_MODEL = "claude-3-5-sonnet-20240620"
 
+# Default model specifically for planning tasks
+DEFAULT_PLANNING_MODEL = DEFAULT_CONTEXT_MODEL
+
 def get_model_display_name(model_id):
     """Get the display name for a model ID."""
     # Check Claude models

--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -5,7 +5,10 @@ import json
 from typing import Dict, Any
 
 from showup_core.api_client import generate_with_claude
-from showup_core.model_config import get_model_provider
+from showup_core.model_config import (
+    get_model_provider,
+    DEFAULT_PLANNING_MODEL,
+)
 from .block_library import get_block_type_definitions, validate_plan
 
 logger = logging.getLogger(__name__)
@@ -55,7 +58,7 @@ async def run_planning_stage(
         .replace("{{block_library}}", block_defs)
     )
 
-    model_id = config.get('model_id', 'claude-3-haiku-20240307')
+    model_id = config.get('model_id', DEFAULT_PLANNING_MODEL)
     provider = get_model_provider(model_id)
 
     max_attempts = config.get("max_attempts", 3)

--- a/showup_tools/workflow.py
+++ b/showup_tools/workflow.py
@@ -30,6 +30,7 @@ from simplified_workflow.markdown_utils import insert_sections_in_markdown
 from .constants import EXCEL_CLARIFICATION
 
 from showup_core.api_client import generate_with_claude
+from showup_core.model_config import DEFAULT_PLANNING_MODEL
 # Import RAG system components
 from simplified_workflow.rag_system.token_counter import count_tokens
 from simplified_workflow.rag_system.cache_manager import cache
@@ -340,7 +341,8 @@ async def process_row_for_phase(row_data_item: Dict[str, Any], phase: str, csv_r
             add_log_entry("Planning", "started", "Generating initial plan")
             plan_cfg = {
                 "model_id": ui_settings.get(
-                    "planning_model", ui_settings.get("selected_model", "claude-3-haiku-20240307")
+                    "planning_model",
+                    ui_settings.get("selected_model", DEFAULT_PLANNING_MODEL),
                 ),
                 "max_tokens": ui_settings.get("planning_max_tokens", 8000),
                 "temperature": ui_settings.get("planning_temperature", 0.3),


### PR DESCRIPTION
## Summary
- expose `DEFAULT_PLANNING_MODEL` in model_config
- select planning model dynamically in planning_stage
- default to the planning model in api_client when task_type includes planning
- update workflow and main configuration to use the planning default

## Testing
- `python -m py_compile showup_core/model_config.py showup_tools/planning_stage.py showup_core/api_client.py showup_tools/workflow.py main.py`

------
https://chatgpt.com/codex/tasks/task_b_68747e652a4c8326b9d21ad959f4415b