### PR TITLE
Update PlanModel to use Annotated union

### DIFF
--- a/showup_tools/models/generation_output.py
+++ b/showup_tools/models/generation_output.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Literal, Dict, Any, Optional, Union
+from typing import List, Literal, Dict, Any, Optional, Union, Annotated
 from pydantic import BaseModel, Field
 
 class SentimentAnalysis(BaseModel):
@@ -193,20 +193,23 @@ class ImagePlaceholder(BaseModel):
     placement_suggestion: Optional[str] = None
 
 
-AnyBlock = Union[
-    LessonMetadata,
-    LearningObjectives,
-    Introduction,
-    SectionHeading,
-    ExplanatoryText,
-    ListBlock,
-    ExampleAnalysis,
-    ProcessSteps,
-    ReflectionPrompt,
-    KeyTakeaways,
-    DiagramPlaceholder,
-    FlowchartPlaceholder,
-    ImagePlaceholder,
+AnyBlock = Annotated[
+    Union[
+        LessonMetadata,
+        LearningObjectives,
+        Introduction,
+        SectionHeading,
+        ExplanatoryText,
+        ListBlock,
+        ExampleAnalysis,
+        ProcessSteps,
+        ReflectionPrompt,
+        KeyTakeaways,
+        DiagramPlaceholder,
+        FlowchartPlaceholder,
+        ImagePlaceholder,
+    ],
+    Field(discriminator='block_type')
 ]
 
 
@@ -216,4 +219,4 @@ class PlanModel(BaseModel):
     content_title: str
     target_audience: str
     estimated_word_count: int
-    content_blocks: List[AnyBlock] = Field(..., discriminator='block_type')
+    content_blocks: List[AnyBlock]


### PR DESCRIPTION
## Summary
- swap plain `Union` for `Annotated` union in `generation_output.py`
- remove discriminator from `PlanModel.content_blocks`
- adjust imports for `Annotated`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_b_687488586e788326ba08634ceec71209