### PR TITLE
Add template directory setting

### DIFF
--- a/showup_tools/README.md
+++ b/showup_tools/README.md
@@ -68,3 +68,10 @@ pytest
 - Support for learner profiles and student handbooks
 - Configurable output settings
 - Logging and error handling
+- Optional template directory setting for custom content templates
+
+### Template Directory
+
+You can choose a folder containing your own markdown templates. In the UI this
+is saved as the `template_directory` setting. If omitted, the app loads the
+default template from the repository's `templates/` folder.

--- a/showup_tools/content_generator.py
+++ b/showup_tools/content_generator.py
@@ -283,12 +283,19 @@ def extract_educational_content(content: str) -> str:
         logger.warning("Educational content tags not found, returning original content")
         return content
 
-def load_content_generation_template() -> str:
-    """
-    Load the content generation template.
-    
+from pathlib import Path
+
+def load_content_generation_template(ui_settings: Optional[Dict[str, Any]] = None) -> str:
+    """Load the content generation template.
+
+    Args:
+        ui_settings: Optional settings dict. If it contains a
+            ``template_directory`` key, templates will be loaded from this
+            directory. Otherwise the default ``templates`` folder in the
+            repository root is used.
+
     Returns:
-        Template string for content generation
+        Template string for content generation.
     """
     # IMPORTANT NOTES: 
     # 1. All content generation will now use high-school-lesson-template structure regardless of
@@ -298,9 +305,16 @@ def load_content_generation_template() -> str:
     # 3. The system maintains a fallback mechanism below to prevent workflow failures
     #    if templates are missing
     
-    # Path to templates directory specified by user
-    template_dir = r"C:\Users\User\Desktop\ShowupSquaredV4 (2)\ShowupSquaredV4\ShowupSquaredV4\showup_tools\simplified_app\templates"
-    template_path = os.path.join(template_dir, "high-school-lesson-template.md")
+    if ui_settings is None:
+        ui_settings = {}
+
+    template_dir_setting = ui_settings.get("template_directory")
+    if template_dir_setting:
+        template_dir = Path(template_dir_setting)
+    else:
+        template_dir = Path(__file__).resolve().parents[1] / "templates"
+
+    template_path = template_dir / "high-school-lesson-template.md"
     
     logger.info(f"Loading content generation template from {template_path}")
     
@@ -314,8 +328,8 @@ def load_content_generation_template() -> str:
     
     # Try to load the template from file
     try:
-        if os.path.exists(template_path):
-            with open(template_path, 'r', encoding='utf-8') as file:
+        if template_path.exists():
+            with template_path.open('r', encoding='utf-8') as file:
                 template = file.read()
                 logger.info("Successfully loaded template from file")
                 return template

--- a/showup_tools/workflow.py
+++ b/showup_tools/workflow.py
@@ -912,7 +912,7 @@ async def main(csv_path: str,
                 
                 # 3. Load template
                 add_log_entry("Load Template", "started", "Loading content generation template")
-                template = load_content_generation_template()
+                template = load_content_generation_template(ui_settings)
                 add_log_entry("Load Template", "completed", "Template loaded successfully")
                 
                 # Store data for this row


### PR DESCRIPTION
## Summary
- allow `load_content_generation_template` to read `template_directory` from UI settings and default to repository templates
- pass UI settings to the loader in workflow
- document the new setting in the app README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68748b24d2188326913436f9edd0f057