### PR TITLE
Move prompts to dedicated directory and add loader

### DIFF
--- a/prompts/generation/fallback_lesson_template.txt
+++ b/prompts/generation/fallback_lesson_template.txt
@@ -1,0 +1,21 @@
+You are a professional physical education curriculum developer creating NEW original educational content for a physical education course.
+
+YOUR TASK:
+Create a COMPLETE, ORIGINAL LESSON about {{topic}} for {{target_learner}} in {{course_name}}.
+This lesson should teach {{objective}} through practical, engaging activities and clear explanations.
+
+CONTENT OUTLINE TO COVER:
+{{content_outline}}
+
+CRITICAL INSTRUCTIONS:
+1. Generate COMPLETELY NEW, original educational content (do not ask for text to edit)
+2. Write as a complete, ready-to-use lesson (not template placeholders)
+3. Include clear explanations, examples, and activities relevant to physical education
+4. Use age-appropriate language for {{target_learner}}
+5. Make content practical and actionable for physical education classes
+6. Do not include placeholder text or template instructions in your final output
+7. Format with proper markdown headings, lists, and structure
+8. Focus on creating substantive, instructionally sound content
+
+Your response should be 600-800 words in length. Create high-quality educational content that could be used immediately in a physical education classroom.
+Do not reference this prompt or include meta-commentary - just provide the finished lesson content.

--- a/prompts/generation/generation_prompt.txt
+++ b/prompts/generation/generation_prompt.txt
@@ -1,0 +1,11 @@
+You are generating lesson content block by block.
+The entire lesson should be roughly {{word_count}} words in total.
+Use Markdown formatting when appropriate.
+
+Block details:
+{{block}}
+
+Instruction:
+{{instruction}}
+
+Write only the content for this block.

--- a/prompts/generation/lo_kt_generation_prompt.txt
+++ b/prompts/generation/lo_kt_generation_prompt.txt
@@ -1,0 +1,21 @@
+SYSTEM: You are a veteran curriculum designer. You will read a lesson and extract its learning goals and summary points.
+
+USER:
+"""
+<Lesson Content in Markdown>
+"""
+
+Tasks:
+1. **Learning Objectives:** Write 1-3 bullet-point objectives that describe what a learner will be able to do after this lesson. Use SMART criteria – be Specific, Measurable, Achievable, Relevant, and (if applicable) Time-bound. Start each objective with a strong action verb (e.g. *explain, analyze, create*). Ensure the objectives cover the key skills/knowledge from the lesson content.
+2. **Key Takeaways:** Write 2-4 bullet-point key takeaways that summarize the most important points or insights from the lesson. These should be the crucial facts or concepts a student should remember. Use clear, concise language.
+
+Format the output in Markdown with the following sections:
+
+## Learning Objectives
+- Objective 1...
+- Objective 2...
+
+## Key Takeaways
+- Takeaway 1...
+- Takeaway 2...
+

--- a/prompts/planning/main_lesson_planner.txt
+++ b/prompts/planning/main_lesson_planner.txt
@@ -1,0 +1,195 @@
+You are an expert Instructional Design Architect AI. Your task is to create a detailed, structured lesson plan in JSON format. This plan will serve as a dynamic template for generating educational content.
+
+**Strictly adhere to the following JSON schema for your output.** Every field marked as `REQUIRED` must be present and correctly populated.
+
+**Output JSON Schema (PlanModel):**
+
+```
+{
+  "content_title": "string (REQUIRED)",
+  "target_audience": "string (REQUIRED)",
+  "estimated_word_count": "integer (REQUIRED)",
+  "content_blocks": [
+    // Array of content block objects, each structured as defined below.
+    // At least one block of type 'introduction' and 'section_heading' is expected.
+  ]
+}
+
+```
+
+**Content Block Library (Detailed Schema):**
+
+For each object within the `content_blocks` array, choose ONE `block_type` from the list below and populate ALL its `REQUIRED` attributes.
+
+1. **lesson\_metadata**:  
+   * `block_type`: "lesson\_metadata" (string, REQUIRED)  
+   * `title`: "string (REQUIRED)" \- The main title of the lesson.  
+   * `module_id`: "string (REQUIRED)" \- Unique identifier for the module (e.g., "1.6").  
+   * `subtitle`: "string (Optional)" \- A brief subtitle for the lesson.  
+   * `purpose`: "string (Optional)" \- The overall pedagogical purpose of the lesson.  
+2. **learning\_objectives**:  
+   * `block_type`: "learning\_objectives" (string, REQUIRED)  
+   * `objectives`: "array of strings (REQUIRED)" \- A list of specific, measurable learning objectives for this lesson. (Note: The Planner *intentionally omits* this block from the initial plan, as it's generated later. However, if you are explicitly asked to include it, ensure it's present.)  
+3. **introduction**:  
+   * `block_type`: "introduction" (string, REQUIRED)  
+   * `content_summary`: "string (REQUIRED)" \- A concise summary of what this introduction should cover.  
+   * `hook_suggestion`: "string (Optional)" \- A suggestion for how to engage the learner (e.g., "Relatable scenario," "Provocative question").  
+4. **section\_heading**:  
+   * `block_type`: "section\_heading" (string, REQUIRED)  
+   * `level`: "integer (REQUIRED)" \- The heading level (e.g., 2 for H2, 3 for H3).  
+   * `title`: "string (REQUIRED)" \- The text of the section heading.  
+5. **explanatory\_text**:  
+   * `block_type`: "explanatory\_text" (string, REQUIRED)  
+   * `topic`: "string (REQUIRED)" \- The main topic this text block will explain.  
+   * `key_points`: "array of strings (REQUIRED)" \- A list of essential points to be covered in this explanation.  
+   * `tone_suggestion`: "string (Optional)" \- Suggested tone (e.g., "informative," "conversational," "formal").  
+6. **list\_block**:  
+   * `block_type`: "list\_block" (string, REQUIRED)  
+   * `list_type`: "'numbered' | 'bulleted' (REQUIRED)" \- Type of list.  
+   * `items_summary`: "array of strings (REQUIRED)" \- A summary of each item in the list.  
+   * `heading`: "string (Optional)" \- An optional heading for the list.  
+7. **example\_analysis**:  
+   * `block_type`: "example\_analysis" (string, REQUIRED)  
+   * `example_title`: "string (REQUIRED)" \- Title of the example.  
+   * `initial_statement`: "string (REQUIRED)" \- The initial statement or scenario to be analyzed.  
+   * `analysis_criteria`: "array of strings (REQUIRED)" \- Key criteria or points to focus on during the analysis.  
+   * `improved_version_summary`: "string (REQUIRED)" \- A summary of how the example could be improved.  
+   * `explanation_points`: "array of strings (REQUIRED)" \- Key takeaways or explanations from the analysis.  
+8. **process\_steps**:  
+   * `block_type`: "process\_steps" (string, REQUIRED)  
+   * `process_name`: "string (REQUIRED)" \- The name of the process being described.  
+   * `steps`: "array of objects (REQUIRED)" \- Each object should have `step_number: int` and `description: string`.  
+   * `introductory_text`: "string (Optional)" \- Optional introductory text for the process.  
+9. **reflection\_prompt**:  
+   * `block_type`: "reflection\_prompt" (string, REQUIRED)  
+   * `prompt_heading`: "string (REQUIRED)" \- The main heading for the reflection prompt.  
+   * `questions`: "array of strings (REQUIRED)" \- A list of questions for the learner to reflect upon.  
+   * `context_setting`: "string (Optional)" \- Optional context or scenario for the reflection.  
+10. **key\_takeaways**:  
+    * `block_type`: "key\_takeaways" (string, REQUIRED)  
+    * `points`: "array of strings (REQUIRED)" \- A list of the main takeaways from the lesson. (Note: The Planner *intentionally omits* this block from the initial plan, as it's generated later. However, if you are explicitly asked to include it, ensure it's present.)  
+11. **diagram\_placeholder**:  
+    * `block_type`: "diagram\_placeholder" (string, REQUIRED)  
+    * `concept_to_illustrate`: "string (REQUIRED)" \- The key concept the diagram should visually represent.  
+    * `description`: "string (REQUIRED)" \- A detailed description of the diagram's content and purpose.  
+12. **flowchart\_placeholder**:  
+    * `block_type`: "flowchart\_placeholder" (string, REQUIRED)  
+    * `process_name`: "string (REQUIRED)" \- The name of the process the flowchart should illustrate.  
+    * `description`: "string (REQUIRED)" \- A detailed description of the flowchart's content and flow.  
+13. **image\_placeholder**:  
+    * `block_type`: "image\_placeholder" (string, REQUIRED)  
+    * `description`: "string (REQUIRED)" \- A detailed description of the image content and its relevance.  
+    * `caption`: "string (Optional)" \- An optional caption for the image.  
+14. **audio\_placeholder**:  
+    * `block_type`: "audio\_placeholder" (string, REQUIRED)  
+    * `topic`: "string (REQUIRED)" \- The topic of the audio content.  
+    * `description`: "string (REQUIRED)" \- A detailed description of the audio content.  
+    * `suggested_duration_seconds`: "integer (Optional)" \- Suggested duration in seconds.  
+15. **video\_placeholder**:  
+    * `block_type`: "video\_placeholder" (string, REQUIRED)  
+    * `topic`: "string (REQUIRED)" \- The topic of the video content.  
+    * `description`: "string (REQUIRED)" \- A detailed description of the video content.  
+    * `suggested_duration_seconds`: "integer (Optional)" \- Suggested duration in seconds.
+
+**Instructions for the AI:**
+
+* Generate a complete JSON object that strictly adheres to the `PlanModel` schema.
+* Include the top-level fields `content_title`, `target_audience`, and `estimated_word_count`.
+* For each item in the `content_blocks` array, choose one `block_type` and provide *all* its `REQUIRED` attributes.
+* **Crucially, ensure that the `"block_type"` field is present within *each* block object in the `content_blocks` array.**  
+* Populate the content summaries and descriptions thoughtfully, based on the provided lesson context.  
+* Prioritize pedagogical flow and logical progression of content.  
+* Remember that `learning_objectives` and `key_takeaways` are typically omitted from the *initial plan* unless explicitly requested otherwise for a specific scenario, as they are generated in a later stage.
+* Respond only with valid JSON; use double quotes for keys and strings and avoid trailing commas or extra text.
+
+**Example of a correctly structured `initial_plan` JSON (for illustrative purposes):**
+
+```
+{
+  "content_title": "Understanding Photosynthesis",
+  "target_audience": "High School Biology Students",
+  "estimated_word_count": 1200,
+  "content_blocks": [
+    {
+      "block_type": "lesson_metadata",
+      "title": "The Magic of Photosynthesis",
+      "module_id": "Bio101-Mod2",
+      "purpose": "To introduce the fundamental process of photosynthesis."
+    },
+    {
+      "block_type": "introduction",
+      "content_summary": "Engage students with the concept of how plants make food and its importance for life on Earth.",
+      "hook_suggestion": "Start with a question about where plant energy comes from."
+    },
+    {
+      "block_type": "section_heading",
+      "level": 2,
+      "title": "What is Photosynthesis?"
+    },
+    {
+      "block_type": "explanatory_text",
+      "topic": "Definition and basic overview of photosynthesis",
+      "key_points": [
+        "Process used by plants, algae, and cyanobacteria",
+        "Converts light energy into chemical energy (sugars)",
+        "Uses carbon dioxide and water, releases oxygen"
+      ],
+      "tone_suggestion": "informative and engaging"
+    },
+    {
+      "block_type": "image_placeholder",
+      "description": "A simple diagram illustrating the inputs and outputs of photosynthesis (sunlight, CO2, H2O -> Glucose, O2).",
+      "caption": "The essential elements of photosynthesis."
+    },
+    {
+      "block_type": "section_heading",
+      "level": 2,
+      "title": "The Light-Dependent Reactions"
+    },
+    {
+      "block_type": "explanatory_text",
+      "topic": "Detailed explanation of light-dependent reactions",
+      "key_points": [
+        "Occur in thylakoid membranes of chloroplasts",
+        "Requires light energy",
+        "Produces ATP and NADPH"
+      ],
+      "tone_suggestion": "detailed and scientific"
+    },
+    {
+      "block_type": "diagram_placeholder",
+      "concept_to_illustrate": "Electron transport chain in light-dependent reactions",
+      "description": "A flowchart showing the movement of electrons, ATP synthase, and NADPH formation."
+    },
+    {
+      "block_type": "section_heading",
+      "level": 2,
+      "title": "The Light-Independent Reactions (Calvin Cycle)"
+    },
+    {
+      "block_type": "explanatory_text",
+      "topic": "Detailed explanation of light-independent reactions (Calvin Cycle)",
+      "key_points": [
+        "Occur in the stroma of chloroplasts",
+        "Does not directly require light",
+        "Uses ATP and NADPH from light reactions to fix CO2 into glucose"
+      ],
+      "tone_suggestion": "informative and clear"
+    },
+    {
+      "block_type": "image_placeholder",
+      "description": "An image representing the overall process of photosynthesis, showing chloroplasts and the flow of energy.",
+      "caption": "Photosynthesis: The foundation of life."
+    },
+    {
+      "block_type": "reflection_prompt",
+      "prompt_heading": "Reflect on Photosynthesis",
+      "questions": [
+        "How do light-dependent and light-independent reactions work together?",
+        "What is the significance of photosynthesis for all living organisms?"
+      ],
+      "context_setting": "Consider the interconnectedness of these processes."
+    }
+  ]
+}
+```

--- a/prompts/planning/plan_critique_prompt.txt
+++ b/prompts/planning/plan_critique_prompt.txt
@@ -1,0 +1,14 @@
+You are an expert instructional designer. Review the plan below for the given learner profile. The plan consists of an array `content_blocks` using block types from the library.
+
+Block Library:
+{{block_library}}
+
+Provide a short critique focusing on block choice, order and completeness.
+
+Learner Profile:
+{{learner_profile}}
+
+Plan:
+{{initial_plan}}
+
+Critique:

--- a/prompts/planning/plan_refine_prompt.txt
+++ b/prompts/planning/plan_refine_prompt.txt
@@ -1,0 +1,16 @@
+You are an expert instructional designer. Using the learner profile and critique, improve the initial plan. Use only block types from the library. Ensure the plan begins with `lesson_metadata`, includes `image_placeholder` blocks to break up long text, and omit `learning_objectives` and `key_takeaways` blocks (they will be added later).
+
+Block Library:
+{{block_library}}
+
+Learner Profile:
+{{learner_profile}}
+
+Initial Plan:
+{{initial_plan}}
+
+Critique:
+{{critique}}
+
+Respond only with JSON:
+{"content_blocks": [{...}]}

--- a/prompts/review/ai_detection_editing.txt
+++ b/prompts/review/ai_detection_editing.txt
@@ -1,0 +1,46 @@
+You are tasked with editing a piece of writing that has been detected as AI-generated to make it more human-like and suitable for a specific target learner. Your goal is to analyze the text, identify AI-like characteristics, and make appropriate edits using the Claude edit tool.
+
+Here is the detected AI-written text:
+
+<detected_ai_text>
+{content}
+</detected_ai_text>
+
+The following AI patterns were detected:
+{patterns_info}
+
+The target learner for this text is:
+
+<target_learner>
+{target_learner}
+</target_learner>
+
+To complete this task, follow these steps:
+
+1. Analyze the text:
+   - Look for patterns typical of AI-generated content, such as overly formal language, repetitive structures, or lack of personal voice.
+   - Identify any content that may not be suitable or engaging for the target learner.
+
+2. Plan your edits:
+   - Consider how to make the language more natural and conversational.
+   - Think about ways to adapt the content to better suit the target learner's needs and interests.
+   - Plan to vary sentence structures and vocabulary to create a more human-like flow.
+
+3. Make edits using the Claude edit tool:
+   - Use the edit tool to make changes that will make the text more human-like and appropriate for the target learner.
+   - Focus on:
+     a. Simplifying complex sentences if needed for the target learner
+     b. Adding personal anecdotes or examples where appropriate
+     c. Varying sentence length and structure
+     d. Incorporating more natural transitions between ideas
+     e. Adjusting vocabulary to match the target learner's level
+     f. Adding rhetorical questions or conversational elements if suitable
+
+4. Review and refine:
+   - After making your initial edits, review the text again to ensure it reads naturally and meets the needs of the target learner.
+   - Make any final adjustments to improve flow, coherence, and suitability.
+
+5. Provide the edited version:
+   - Present the final edited version of the text, ensuring it is more human-like and appropriate for the target learner.
+
+Please output your edited version of the text within <edited_text> tags. Before the edited text, briefly explain the main changes you made and why they are appropriate for the target learner, enclosing this explanation in <explanation> tags.

--- a/prompts/review/content_comparison_prompt.txt
+++ b/prompts/review/content_comparison_prompt.txt
@@ -1,0 +1,55 @@
+You are tasked with analyzing three generations of content created from the same prompt and creating the best version suited for the target learner. Follow these steps carefully:
+
+1. Review the target learner information:
+<target_learner>
+{target_learner}
+</target_learner>
+
+2. Understand the context:
+<context>
+{educational_context}
+</context>
+
+3. Familiarize yourself with the template structure:
+<template>
+{template_context}
+</template>
+
+4. Examine the three generations of content:
+<generations>
+{formatted_generations}
+</generations>
+
+5. Analyze the generations:
+   a. Identify the strengths and weaknesses of each generation
+   b. Compare how well each generation addresses the needs of the target learner
+   c. Evaluate the adherence to the given template
+   d. Consider the clarity, coherence, and relevance of the content
+
+6. Create the best version:
+   a. Combine the strongest elements from all three generations
+   b. Ensure the content is tailored to the target learner's needs and level of understanding
+   c. Adhere strictly to the provided template structure
+   d. Improve clarity, coherence, and relevance where necessary
+   e. Maintain consistency in tone and style throughout the content
+
+7. Present your final version:
+   a. Use the <best_version> tags to enclose your created content
+   b. Ensure that your version follows the template structure exactly
+
+8. Provide a brief explanation:
+   a. Use the <explanation> tags to justify your choices
+   b. Highlight how your version addresses the target learner's needs
+   c. Explain any significant changes or improvements you made
+
+Your complete response should be structured as follows:
+
+<best_version>
+[Insert your created best version here, following the template structure]
+</best_version>
+
+<explanation>
+[Insert your brief explanation here]
+</explanation>
+
+Remember to focus on creating content that is most suitable for the target learner while adhering to the given template and context.

--- a/prompts/review/content_review_prompt.txt
+++ b/prompts/review/content_review_prompt.txt
@@ -1,0 +1,38 @@
+You are an experienced educational content editor tasked with reviewing and making minor edits to learning material to improve its accessibility for a specific target learner. Your goal is to remove barriers to learning without significantly altering the core content or going overboard with changes.
+
+First, carefully review the target learner profile:
+
+<target_learner_profile>
+{target_learner_profile}
+</target_learner_profile>
+
+Now, review the content that needs to be edited:
+
+<content>
+{content}
+</content>
+
+Your task is to make minor edits to the content that will remove barriers to learning for the target learner profile. Follow these guidelines:
+
+1. Identify potential barriers to learning based on the target learner profile.
+2. Make small, targeted changes to address these barriers. This may include:
+   - Simplifying complex language
+   - Clarifying confusing concepts
+   - Adding brief explanations for unfamiliar terms
+   - Adjusting formatting for better readability
+   - Removing or modifying culturally insensitive content
+3. Maintain the original structure and core message of the content.
+4. Do not add substantial new information or remove large portions of the existing content.
+5. Ensure that your edits are minimal and focused on improving accessibility rather than rewriting the entire piece.
+
+After reviewing and editing the content, provide your output in the following format:
+
+<edited_content>
+[Insert the edited content here, with your minor changes implemented]
+</edited_content>
+
+<edit_summary>
+[Provide a brief summary of the changes you made and why they were necessary for the target learner profile. Limit this to 3-5 bullet points.]
+</edit_summary>
+
+Remember, the goal is to make the content more accessible to the target learner without drastically changing its substance or going overboard with edits.

--- a/prompts/system/ai_editor_system_message.txt
+++ b/prompts/system/ai_editor_system_message.txt
@@ -1,0 +1,1 @@
+You are an expert editor specializing in making AI-generated content more human-like and natural. You excel at identifying patterns typical of AI writing and transforming them into authentic, engaging content that resonates with specific target audiences.

--- a/prompts/system/lo_kt_system_message.txt
+++ b/prompts/system/lo_kt_system_message.txt
@@ -1,0 +1,1 @@
+You are a veteran curriculum designer generating concise learning objectives and key takeaways.

--- a/showup_core/utils.py
+++ b/showup_core/utils.py
@@ -7,6 +7,7 @@ in other more specific modules.
 
 import importlib
 import logging
+import os
 from typing import Any, List
 
 import claude_api
@@ -62,3 +63,29 @@ def safe_convert_to_int(value: Any, default: int = 1, context: str = "value") ->
     except (ValueError, TypeError):
         logger.warning(f"Couldn't convert {context} '{value}' to a number, using {default} instead")
         return default
+
+
+def get_project_root() -> str:
+    """Returns the absolute path to the project root."""
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def load_prompt(prompt_name: str) -> str:
+    """Load a prompt from the /prompts directory.
+
+    Args:
+        prompt_name: Path to the prompt file relative to the /prompts directory
+                      (e.g., 'planning/lesson_plan').
+
+    Returns:
+        The content of the prompt file as a string. Returns an empty string if
+        the file cannot be found.
+    """
+    root_dir = get_project_root()
+    prompt_path = os.path.join(root_dir, 'prompts', f"{prompt_name}.txt")
+    try:
+        with open(prompt_path, 'r', encoding='utf-8') as f:
+            return f.read()
+    except FileNotFoundError:
+        print(f"Error: Prompt file not found at {prompt_path}")
+        return ""

--- a/showup_tools/ai_detector.py
+++ b/showup_tools/ai_detector.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Any, Optional, Tuple
 # Import from core modules
 from showup_core.api_client import generate_with_claude
 from .constants import EXCEL_CLARIFICATION
+from showup_core.utils import load_prompt
 
 # Set up logger
 logger = logging.getLogger("simplified_workflow.ai_detector")
@@ -183,13 +184,7 @@ async def edit_content(
         prompt = _create_editing_prompt(content, detected_patterns, target_learner)
 
         # Create a system prompt
-        system_prompt = (
-            "You are an expert editor specializing in making AI-generated content "
-            "more human-like and natural. You excel at identifying patterns typical "
-            "of AI writing and transforming them into authentic, engaging content "
-            "that resonates with specific target audiences."
-            f"\n\n{EXCEL_CLARIFICATION}"
-        )
+        system_prompt = load_prompt('system/ai_editor_system_message') + f"\n\n{EXCEL_CLARIFICATION}"
 
         # Call Claude API
         # Get token limit from ui_settings if available, otherwise use default
@@ -301,59 +296,14 @@ def _create_editing_prompt(
         )
         return prompt
     except ImportError:
-        logger.warning("Template loader not available, using hardcoded template")
+        logger.warning("Template loader not available, using default template")
 
-        # Create the prompt
-        prompt = f"""
-You are tasked with editing a piece of writing that has been detected as AI-generated to make it more human-like and suitable for a specific target learner. Your goal is to analyze the text, identify AI-like characteristics, and make appropriate edits using the Claude edit tool.
+        template = load_prompt('review/ai_detection_editing')
+        prompt = template.replace("{content}", content)
+        prompt = prompt.replace("{patterns_info}", patterns_info)
+        prompt = prompt.replace("{target_learner}", target_learner)
 
-Here is the detected AI-written text:
-
-<detected_ai_text>
-{content}
-</detected_ai_text>
-
-The following AI patterns were detected:
-{patterns_info}
-
-The target learner for this text is:
-
-<target_learner>
-{target_learner}
-</target_learner>
-
-To complete this task, follow these steps:
-
-1. Analyze the text:
-   - Look for patterns typical of AI-generated content, such as overly formal language, repetitive structures, or lack of personal voice.
-   - Identify any content that may not be suitable or engaging for the target learner.
-
-2. Plan your edits:
-   - Consider how to make the language more natural and conversational.
-   - Think about ways to adapt the content to better suit the target learner's needs and interests.
-   - Plan to vary sentence structures and vocabulary to create a more human-like flow.
-
-3. Make edits using the Claude edit tool:
-   - Use the edit tool to make changes that will make the text more human-like and appropriate for the target learner.
-   - Focus on:
-     a. Simplifying complex sentences if needed for the target learner
-     b. Adding personal anecdotes or examples where appropriate
-     c. Varying sentence length and structure
-     d. Incorporating more natural transitions between ideas
-     e. Adjusting vocabulary to match the target learner's level
-     f. Adding rhetorical questions or conversational elements if suitable
-
-4. Review and refine:
-   - After making your initial edits, review the text again to ensure it reads naturally and meets the needs of the target learner.
-   - Make any final adjustments to improve flow, coherence, and suitability.
-
-5. Provide the edited version:
-   - Present the final edited version of the text, ensuring it is more human-like and appropriate for the target learner.
-
-Please output your edited version of the text within <edited_text> tags. Before the edited text, briefly explain the main changes you made and why they are appropriate for the target learner, enclosing this explanation in <explanation> tags.
-"""
-
-        logger.info(f"Created hardcoded editing prompt ({len(prompt)} characters)")
+        logger.info(f"Created editing prompt from file ({len(prompt)} characters)")
         return prompt
 
 

--- a/showup_tools/content_comparator.py
+++ b/showup_tools/content_comparator.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Any, Optional, Tuple
 # Import from core modules
 from showup_core.api_client import generate_with_claude
 from .constants import EXCEL_CLARIFICATION
+from showup_core.utils import load_prompt
 
 # Set up logger
 logger = logging.getLogger("simplified_workflow.content_comparator")
@@ -211,68 +212,15 @@ def _create_comparison_prompt(generations: List[str],
         logger.info(f"Created comparison prompt from template loader ({len(prompt)} characters)")
         return prompt
     except ImportError:
-        logger.warning("Template loader not available, using hardcoded template")
-        
-        # Create the prompt
-        prompt = f"""
-You are tasked with analyzing three generations of content created from the same prompt and creating the best version suited for the target learner. Follow these steps carefully:
+        logger.warning("Template loader not available, using default template")
 
-1. Review the target learner information:
-<target_learner>
-{target_learner}
-</target_learner>
+        template = load_prompt('review/content_comparison_prompt')
+        prompt = template.replace('{target_learner}', target_learner)
+        prompt = prompt.replace('{educational_context}', educational_context)
+        prompt = prompt.replace('{template_context}', template_context)
+        prompt = prompt.replace('{formatted_generations}', formatted_generations)
 
-2. Understand the context:
-<context>
-{educational_context}
-</context>
-
-3. Familiarize yourself with the template structure:
-<template>
-{template_context}
-</template>
-
-4. Examine the three generations of content:
-<generations>
-{formatted_generations}
-</generations>
-
-5. Analyze the generations:
-   a. Identify the strengths and weaknesses of each generation
-   b. Compare how well each generation addresses the needs of the target learner
-   c. Evaluate the adherence to the given template
-   d. Consider the clarity, coherence, and relevance of the content
-
-6. Create the best version:
-   a. Combine the strongest elements from all three generations
-   b. Ensure the content is tailored to the target learner's needs and level of understanding
-   c. Adhere strictly to the provided template structure
-   d. Improve clarity, coherence, and relevance where necessary
-   e. Maintain consistency in tone and style throughout the content
-
-7. Present your final version:
-   a. Use the <best_version> tags to enclose your created content
-   b. Ensure that your version follows the template structure exactly
-
-8. Provide a brief explanation:
-   a. Use the <explanation> tags to justify your choices
-   b. Highlight how your version addresses the target learner's needs
-   c. Explain any significant changes or improvements you made
-
-Your complete response should be structured as follows:
-
-<best_version>
-[Insert your created best version here, following the template structure]
-</best_version>
-
-<explanation>
-[Insert your brief explanation here]
-</explanation>
-
-Remember to focus on creating content that is most suitable for the target learner while adhering to the given template and context.
-"""
-        
-        logger.info(f"Created hardcoded comparison prompt ({len(prompt)} characters)")
+        logger.info(f"Created comparison prompt from file ({len(prompt)} characters)")
         return prompt
 
 def _extract_comparison_results(result: str) -> Tuple[str, str]:

--- a/showup_tools/content_generator.py
+++ b/showup_tools/content_generator.py
@@ -17,6 +17,7 @@ from showup_core.api_client import generate_with_claude
 # Import RAG system
 from simplified_workflow.rag_system import enhanced_generate_content
 from .constants import EXCEL_CLARIFICATION
+from showup_core.utils import load_prompt
 
 # Set up logger
 logger = logging.getLogger("simplified_workflow.content_generator")
@@ -186,17 +187,10 @@ async def generate_three_versions_from_plan(final_plan: Dict[str, Any], ui_setti
 
     use_dynamic = ui_settings.get("use_dynamic_blocks", True)
 
-    prompt_path = os.path.join(
-        os.path.dirname(__file__),
-        "prompts",
-        "generation_prompt.txt" if use_dynamic else "generation_prompt_legacy.txt",
-    )
-    try:
-        with open(prompt_path, "r", encoding="utf-8") as f:
-            prompt_template = f.read()
-    except FileNotFoundError:
-        logger.error(f"Generation prompt not found: {prompt_path}")
-        raise
+    prompt_template = load_prompt("generation/generation_prompt")
+    if not prompt_template:
+        logger.error("Generation prompt not found")
+        raise FileNotFoundError("generation prompt missing")
 
     max_tokens = ui_settings.get("generation_settings", {}).get("max_tokens", 4000)
     freq_pen = ui_settings.get("generation_settings", {}).get("frequency_penalty", 0.0)

--- a/showup_tools/content_reviewer.py
+++ b/showup_tools/content_reviewer.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Any, Optional, Tuple
 # Import from core modules
 from showup_core.api_client import generate_with_claude
 from .constants import EXCEL_CLARIFICATION
+from showup_core.utils import load_prompt
 
 # Set up logger
 logger = logging.getLogger("simplified_workflow.content_reviewer")
@@ -149,51 +150,13 @@ def _create_review_prompt(content: str, target_learner_profile: str) -> str:
         logger.info(f"Created review prompt from template loader ({len(prompt)} characters)")
         return prompt
     except ImportError:
-        logger.warning("Template loader not available, using hardcoded template")
-        
-        # Create the prompt
-        prompt = f"""
-You are an experienced educational content editor tasked with reviewing and making minor edits to learning material to improve its accessibility for a specific target learner. Your goal is to remove barriers to learning without significantly altering the core content or going overboard with changes.
+        logger.warning("Template loader not available, using default template")
 
-First, carefully review the target learner profile:
+        template = load_prompt('review/content_review_prompt')
+        prompt = template.replace('{content}', content)
+        prompt = prompt.replace('{target_learner_profile}', target_learner_profile)
 
-<target_learner_profile>
-{target_learner_profile}
-</target_learner_profile>
-
-Now, review the content that needs to be edited:
-
-<content>
-{content}
-</content>
-
-Your task is to make minor edits to the content that will remove barriers to learning for the target learner profile. Follow these guidelines:
-
-1. Identify potential barriers to learning based on the target learner profile.
-2. Make small, targeted changes to address these barriers. This may include:
-   - Simplifying complex language
-   - Clarifying confusing concepts
-   - Adding brief explanations for unfamiliar terms
-   - Adjusting formatting for better readability
-   - Removing or modifying culturally insensitive content
-3. Maintain the original structure and core message of the content.
-4. Do not add substantial new information or remove large portions of the existing content.
-5. Ensure that your edits are minimal and focused on improving accessibility rather than rewriting the entire piece.
-
-After reviewing and editing the content, provide your output in the following format:
-
-<edited_content>
-[Insert the edited content here, with your minor changes implemented]
-</edited_content>
-
-<edit_summary>
-[Provide a brief summary of the changes you made and why they were necessary for the target learner profile. Limit this to 3-5 bullet points.]
-</edit_summary>
-
-Remember, the goal is to make the content more accessible to the target learner without drastically changing its substance or going overboard with edits.
-"""
-        
-        logger.info(f"Created hardcoded review prompt ({len(prompt)} characters)")
+        logger.info(f"Created review prompt from file ({len(prompt)} characters)")
         return prompt
 
 def _extract_review_results(result: str) -> Tuple[str, str]:

--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -9,12 +9,11 @@ from showup_core.model_config import (
     get_model_provider,
     DEFAULT_PLANNING_MODEL,
 )
+from showup_core.utils import load_prompt
 from .block_library import get_block_type_definitions, validate_plan
 
 logger = logging.getLogger(__name__)
 
-PROMPTS_DIR = os.path.join(os.path.dirname(__file__), "prompts")
-PLANNING_PROMPT_PATH = os.path.join(PROMPTS_DIR, "planning_prompt.txt")
 
 async def run_planning_stage(
     row_data_item: Dict[str, Any], config: Dict[str, Any]
@@ -24,15 +23,13 @@ async def run_planning_stage(
 
     new_item = row_data_item.copy()
 
-    prompt_path = config.get("planning_prompt_path") or PLANNING_PROMPT_PATH
-
-    try:
-        with open(prompt_path, "r", encoding="utf-8") as f:
-            prompt_template = f.read()
-    except FileNotFoundError:
-        logger.error(f"Planning prompt not found: {prompt_path}")
+    prompt_template = load_prompt(
+        config.get("planning_prompt_path", "planning/main_lesson_planner")
+    )
+    if not prompt_template:
+        logger.error("Planning prompt not found")
         new_item["status"] = "PLAN_FAILED"
-        new_item["error"] = f"Prompt not found: {prompt_path}"
+        new_item["error"] = "Prompt not found"
         return new_item
 
     content_outline = new_item.get("Content Outline") or new_item.get(

--- a/showup_tools/refinement_stage.py
+++ b/showup_tools/refinement_stage.py
@@ -5,13 +5,11 @@ from typing import Dict, Any
 
 from showup_core.api_client import generate_with_claude
 from showup_core.model_config import get_model_provider
+from showup_core.utils import load_prompt
 from .block_library import get_block_type_definitions, validate_plan
 
 logger = logging.getLogger(__name__)
 
-PROMPTS_DIR = os.path.join(os.path.dirname(__file__), 'prompts')
-CRITIQUE_PROMPT_PATH = os.path.join(PROMPTS_DIR, "plan_critique_prompt.txt")
-REFINE_PROMPT_PATH = os.path.join(PROMPTS_DIR, "plan_refine_prompt.txt")
 
 async def run_refinement_stage(
     row_data_item: Dict[str, Any], config: Dict[str, Any]
@@ -21,24 +19,16 @@ async def run_refinement_stage(
 
     new_item = row_data_item.copy()
 
-    critique_path = config.get(
-        "critique_prompt_path",
-        CRITIQUE_PROMPT_PATH,
+    critique_template = load_prompt(
+        config.get("critique_prompt_path", "planning/plan_critique_prompt")
     )
-    refine_path = config.get(
-        "refine_prompt_path",
-        REFINE_PROMPT_PATH,
+    refine_template = load_prompt(
+        config.get("refine_prompt_path", "planning/plan_refine_prompt")
     )
-
-    try:
-        with open(critique_path, "r", encoding="utf-8") as f:
-            critique_template = f.read()
-        with open(refine_path, "r", encoding="utf-8") as f:
-            refine_template = f.read()
-    except FileNotFoundError as e:
-        logger.error(f"Refinement prompt not found: {e}")
+    if not critique_template or not refine_template:
+        logger.error("Refinement prompts not found")
         new_item["status"] = "PLAN_FAILED"
-        new_item["error"] = f"Prompt not found: {e}"
+        new_item["error"] = "Prompt not found"
         return new_item
 
     learner_profile = new_item.get("Learner Profile") or new_item.get(

--- a/simplified_workflow/ai_detector.py
+++ b/simplified_workflow/ai_detector.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Any, Optional, Tuple
 # Import from core modules
 from showup_core.api_client import generate_with_claude
 from .constants import EXCEL_CLARIFICATION
+from showup_core.utils import load_prompt
 
 # Set up logger
 logger = logging.getLogger("simplified_workflow.ai_detector")
@@ -165,13 +166,7 @@ async def edit_content(content: str, detected_patterns: Dict[str, Any], target_l
         prompt = _create_editing_prompt(content, detected_patterns, target_learner)
         
         # Create a system prompt
-        system_prompt = (
-            "You are an expert editor specializing in making AI-generated content "
-            "more human-like and natural. You excel at identifying patterns typical "
-            "of AI writing and transforming them into authentic, engaging content "
-            "that resonates with specific target audiences."
-            f"\n\n{EXCEL_CLARIFICATION}"
-        )
+        system_prompt = load_prompt('system/ai_editor_system_message') + f"\n\n{EXCEL_CLARIFICATION}"
         
         # Call Claude API
         # Get token limit from ui_settings if available, otherwise use default
@@ -268,59 +263,14 @@ def _create_editing_prompt(content: str, detected_patterns: Dict[str, Any], targ
         logger.info(f"Created editing prompt from template loader ({len(prompt)} characters)")
         return prompt
     except ImportError:
-        logger.warning("Template loader not available, using hardcoded template")
-        
-        # Create the prompt
-        prompt = f"""
-You are tasked with editing a piece of writing that has been detected as AI-generated to make it more human-like and suitable for a specific target learner. Your goal is to analyze the text, identify AI-like characteristics, and make appropriate edits using the Claude edit tool.
+        logger.warning("Template loader not available, using default template")
 
-Here is the detected AI-written text:
+        template = load_prompt('review/ai_detection_editing')
+        prompt = template.replace("{content}", content)
+        prompt = prompt.replace("{patterns_info}", patterns_info)
+        prompt = prompt.replace("{target_learner}", target_learner)
 
-<detected_ai_text>
-{content}
-</detected_ai_text>
-
-The following AI patterns were detected:
-{patterns_info}
-
-The target learner for this text is:
-
-<target_learner>
-{target_learner}
-</target_learner>
-
-To complete this task, follow these steps:
-
-1. Analyze the text:
-   - Look for patterns typical of AI-generated content, such as overly formal language, repetitive structures, or lack of personal voice.
-   - Identify any content that may not be suitable or engaging for the target learner.
-
-2. Plan your edits:
-   - Consider how to make the language more natural and conversational.
-   - Think about ways to adapt the content to better suit the target learner's needs and interests.
-   - Plan to vary sentence structures and vocabulary to create a more human-like flow.
-
-3. Make edits using the Claude edit tool:
-   - Use the edit tool to make changes that will make the text more human-like and appropriate for the target learner.
-   - Focus on:
-     a. Simplifying complex sentences if needed for the target learner
-     b. Adding personal anecdotes or examples where appropriate
-     c. Varying sentence length and structure
-     d. Incorporating more natural transitions between ideas
-     e. Adjusting vocabulary to match the target learner's level
-     f. Adding rhetorical questions or conversational elements if suitable
-
-4. Review and refine:
-   - After making your initial edits, review the text again to ensure it reads naturally and meets the needs of the target learner.
-   - Make any final adjustments to improve flow, coherence, and suitability.
-
-5. Provide the edited version:
-   - Present the final edited version of the text, ensuring it is more human-like and appropriate for the target learner.
-
-Please output your edited version of the text within <edited_text> tags. Before the edited text, briefly explain the main changes you made and why they are appropriate for the target learner, enclosing this explanation in <explanation> tags.
-"""
-        
-        logger.info(f"Created hardcoded editing prompt ({len(prompt)} characters)")
+        logger.info(f"Created editing prompt from file ({len(prompt)} characters)")
         return prompt
 
 def _extract_editing_results(result: str) -> Tuple[str, str]:

--- a/simplified_workflow/content_comparator.py
+++ b/simplified_workflow/content_comparator.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Any, Optional, Tuple
 # Import from core modules
 from showup_core.api_client import generate_with_claude
 from .constants import EXCEL_CLARIFICATION
+from showup_core.utils import load_prompt
 
 # Set up logger
 logger = logging.getLogger("simplified_workflow.content_comparator")
@@ -211,68 +212,15 @@ def _create_comparison_prompt(generations: List[str],
         logger.info(f"Created comparison prompt from template loader ({len(prompt)} characters)")
         return prompt
     except ImportError:
-        logger.warning("Template loader not available, using hardcoded template")
-        
-        # Create the prompt
-        prompt = f"""
-You are tasked with analyzing three generations of content created from the same prompt and creating the best version suited for the target learner. Follow these steps carefully:
+        logger.warning("Template loader not available, using default template")
 
-1. Review the target learner information:
-<target_learner>
-{target_learner}
-</target_learner>
+        template = load_prompt('review/content_comparison_prompt')
+        prompt = template.replace('{target_learner}', target_learner)
+        prompt = prompt.replace('{educational_context}', educational_context)
+        prompt = prompt.replace('{template_context}', template_context)
+        prompt = prompt.replace('{formatted_generations}', formatted_generations)
 
-2. Understand the context:
-<context>
-{educational_context}
-</context>
-
-3. Familiarize yourself with the template structure:
-<template>
-{template_context}
-</template>
-
-4. Examine the three generations of content:
-<generations>
-{formatted_generations}
-</generations>
-
-5. Analyze the generations:
-   a. Identify the strengths and weaknesses of each generation
-   b. Compare how well each generation addresses the needs of the target learner
-   c. Evaluate the adherence to the given template
-   d. Consider the clarity, coherence, and relevance of the content
-
-6. Create the best version:
-   a. Combine the strongest elements from all three generations
-   b. Ensure the content is tailored to the target learner's needs and level of understanding
-   c. Adhere strictly to the provided template structure
-   d. Improve clarity, coherence, and relevance where necessary
-   e. Maintain consistency in tone and style throughout the content
-
-7. Present your final version:
-   a. Use the <best_version> tags to enclose your created content
-   b. Ensure that your version follows the template structure exactly
-
-8. Provide a brief explanation:
-   a. Use the <explanation> tags to justify your choices
-   b. Highlight how your version addresses the target learner's needs
-   c. Explain any significant changes or improvements you made
-
-Your complete response should be structured as follows:
-
-<best_version>
-[Insert your created best version here, following the template structure]
-</best_version>
-
-<explanation>
-[Insert your brief explanation here]
-</explanation>
-
-Remember to focus on creating content that is most suitable for the target learner while adhering to the given template and context.
-"""
-        
-        logger.info(f"Created hardcoded comparison prompt ({len(prompt)} characters)")
+        logger.info(f"Created comparison prompt from file ({len(prompt)} characters)")
         return prompt
 
 def _extract_comparison_results(result: str) -> Tuple[str, str]:

--- a/simplified_workflow/content_generator.py
+++ b/simplified_workflow/content_generator.py
@@ -16,6 +16,7 @@ from showup_core.api_client import generate_with_claude
 # Import RAG system
 from simplified_workflow.rag_system import enhanced_generate_content
 from .constants import EXCEL_CLARIFICATION
+from showup_core.utils import load_prompt
 
 # Set up logger
 logger = logging.getLogger("simplified_workflow.content_generator")
@@ -337,29 +338,7 @@ def load_content_generation_template() -> str:
     
     # Fallback template if file loading fails
     logger.warning("Using fallback hardcoded template")
-    template = """
-    You are a professional physical education curriculum developer creating NEW original educational content for a physical education course.
-        
-    YOUR TASK:
-    Create a COMPLETE, ORIGINAL LESSON about {{topic}} for {{target_learner}} in {{course_name}}.
-    This lesson should teach {{objective}} through practical, engaging activities and clear explanations.
-    
-    CONTENT OUTLINE TO COVER:
-    {{content_outline}}
-    
-    CRITICAL INSTRUCTIONS:
-    1. Generate COMPLETELY NEW, original educational content (do not ask for text to edit)
-    2. Write as a complete, ready-to-use lesson (not template placeholders)
-    3. Include clear explanations, examples, and activities relevant to physical education
-    4. Use age-appropriate language for {{target_learner}}
-    5. Make content practical and actionable for physical education classes
-    6. Do not include placeholder text or template instructions in your final output
-    7. Format with proper markdown headings, lists, and structure
-    8. Focus on creating substantive, instructionally sound content
-    
-    Your response should be 600-800 words in length. Create high-quality educational content that could be used immediately in a physical education classroom.
-    Do not reference this prompt or include meta-commentary - just provide the finished lesson content.
-    """
-    
+    template = load_prompt('generation/fallback_lesson_template')
+
     logger.info(f"Using default content generation template ({len(template)} characters)")
     return template

--- a/simplified_workflow/content_reviewer.py
+++ b/simplified_workflow/content_reviewer.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Any, Optional, Tuple
 # Import from core modules
 from showup_core.api_client import generate_with_claude
 from .constants import EXCEL_CLARIFICATION
+from showup_core.utils import load_prompt
 
 # Set up logger
 logger = logging.getLogger("simplified_workflow.content_reviewer")
@@ -149,51 +150,13 @@ def _create_review_prompt(content: str, target_learner_profile: str) -> str:
         logger.info(f"Created review prompt from template loader ({len(prompt)} characters)")
         return prompt
     except ImportError:
-        logger.warning("Template loader not available, using hardcoded template")
-        
-        # Create the prompt
-        prompt = f"""
-You are an experienced educational content editor tasked with reviewing and making minor edits to learning material to improve its accessibility for a specific target learner. Your goal is to remove barriers to learning without significantly altering the core content or going overboard with changes.
+        logger.warning("Template loader not available, using default template")
 
-First, carefully review the target learner profile:
+        template = load_prompt('review/content_review_prompt')
+        prompt = template.replace('{content}', content)
+        prompt = prompt.replace('{target_learner_profile}', target_learner_profile)
 
-<target_learner_profile>
-{target_learner_profile}
-</target_learner_profile>
-
-Now, review the content that needs to be edited:
-
-<content>
-{content}
-</content>
-
-Your task is to make minor edits to the content that will remove barriers to learning for the target learner profile. Follow these guidelines:
-
-1. Identify potential barriers to learning based on the target learner profile.
-2. Make small, targeted changes to address these barriers. This may include:
-   - Simplifying complex language
-   - Clarifying confusing concepts
-   - Adding brief explanations for unfamiliar terms
-   - Adjusting formatting for better readability
-   - Removing or modifying culturally insensitive content
-3. Maintain the original structure and core message of the content.
-4. Do not add substantial new information or remove large portions of the existing content.
-5. Ensure that your edits are minimal and focused on improving accessibility rather than rewriting the entire piece.
-
-After reviewing and editing the content, provide your output in the following format:
-
-<edited_content>
-[Insert the edited content here, with your minor changes implemented]
-</edited_content>
-
-<edit_summary>
-[Provide a brief summary of the changes you made and why they were necessary for the target learner profile. Limit this to 3-5 bullet points.]
-</edit_summary>
-
-Remember, the goal is to make the content more accessible to the target learner without drastically changing its substance or going overboard with edits.
-"""
-        
-        logger.info(f"Created hardcoded review prompt ({len(prompt)} characters)")
+        logger.info(f"Created review prompt from file ({len(prompt)} characters)")
         return prompt
 
 def _extract_review_results(result: str) -> Tuple[str, str]:

--- a/simplified_workflow/learning_sections.py
+++ b/simplified_workflow/learning_sections.py
@@ -2,24 +2,22 @@ import os
 import logging
 from typing import Tuple
 from showup_core.api_client import generate_with_claude
+from showup_core.utils import load_prompt
 
 logger = logging.getLogger(__name__)
 
-PROMPT_PATH = os.path.join(os.path.dirname(__file__), 'prompts', 'lo_kt_generation_prompt.txt')
 
 async def generate_lo_and_kt_from_content(content: str, model: str = 'claude-3-haiku-20240307', max_tokens: int = 800) -> Tuple[str, str]:
     """Generate learning objectives and key takeaways from lesson content."""
-    try:
-        with open(PROMPT_PATH, 'r', encoding='utf-8') as f:
-            prompt_template = f.read()
-    except FileNotFoundError as e:
-        logger.error(f'Prompt file not found: {PROMPT_PATH}')
-        raise
+    prompt_template = load_prompt('generation/lo_kt_generation_prompt')
+    if not prompt_template:
+        logger.error('Prompt file not found')
+        raise FileNotFoundError('lo_kt_generation_prompt missing')
 
     prompt = prompt_template.replace('{{content}}', content)
     response = await generate_with_claude(
         prompt=prompt,
-        system_prompt='You are a veteran curriculum designer generating concise learning objectives and key takeaways.',
+        system_prompt=load_prompt('system/lo_kt_system_message'),
         max_tokens=max_tokens,
         temperature=0.3,
         model=model,


### PR DESCRIPTION
## Summary
- centralize prompt strings in new `prompts/` directory
- add `load_prompt` helper in `showup_core.utils`
- update planning and refinement stages to use new prompts
- refactor generation, review and editing modules to load prompts from files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68748d14762083268e40c8dab34a396d