### PR TITLE
Centralize argument parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from kivy.uix.progressbar import ProgressBar
 from kivy.clock import Clock
 from kivy.properties import StringProperty, BooleanProperty, NumericProperty
 from showup_core.model_config import DEFAULT_PLANNING_MODEL
+from showup_core.config import create_argument_parser
 
 import asyncio
 import threading
@@ -35,6 +36,10 @@ except ImportError as e:
 kivy_logger = logging.getLogger('kivy')
 kivy_logger.setLevel(logging.INFO)
 
+# Parse command line arguments for defaults
+_parser = create_argument_parser()
+CLI_ARGS, _ = _parser.parse_known_args()
+
 class WorkflowApp(App):
     status_message = StringProperty("Ready to start workflow.")
     progress_value = NumericProperty(0)
@@ -48,7 +53,7 @@ class WorkflowApp(App):
         input_grid = BoxLayout(orientation='vertical', size_hint_y=None, height=300, spacing=5)
 
         input_grid.add_widget(Label(text="CSV File Path:", halign='left', size_hint_x=1))
-        self.csv_path_input = TextInput(text="data/sample_input.csv", multiline=False, size_hint_x=1)
+        self.csv_path_input = TextInput(text=CLI_ARGS.csv_file, multiline=False, size_hint_x=1)
         input_grid.add_widget(self.csv_path_input)
         csv_browse_button = Button(text="Browse CSV", size_hint_y=None, height=40)
         csv_browse_button.bind(on_release=lambda btn: self.show_file_chooser(self.csv_path_input, 'csv'))
@@ -62,11 +67,11 @@ class WorkflowApp(App):
         input_grid.add_widget(handbook_browse_button)
 
         input_grid.add_widget(Label(text="Course Name:", halign='left', size_hint_x=1))
-        self.course_name_input = TextInput(text="Introduction to Academic Grit", multiline=False, size_hint_x=1)
+        self.course_name_input = TextInput(text=CLI_ARGS.course_name, multiline=False, size_hint_x=1)
         input_grid.add_widget(self.course_name_input)
 
         input_grid.add_widget(Label(text="Learner Profile:", halign='left', size_hint_x=1))
-        self.learner_profile_input = TextInput(text="A high school student preparing for college.", multiline=True, size_hint_x=1)
+        self.learner_profile_input = TextInput(text=CLI_ARGS.learner_profile, multiline=True, size_hint_x=1)
         input_grid.add_widget(self.learner_profile_input)
 
         main_layout.add_widget(input_grid)
@@ -172,7 +177,8 @@ class WorkflowApp(App):
         os.makedirs(run_output_dir, exist_ok=True)
 
         try:
-            workflow_log_file_path = setup_logging(log_level=logging.DEBUG)
+            log_level = getattr(logging, CLI_ARGS.log_level.upper(), logging.INFO)
+            workflow_log_file_path = setup_logging(log_level=log_level)
         except Exception as e:
             self.status_message = f"[color=ff0000]Error setting up workflow logging: {e}[/color]"
             self.workflow_running = False

--- a/showup_core/config.py
+++ b/showup_core/config.py
@@ -8,6 +8,43 @@ used throughout the application.
 import os
 import logging
 from pathlib import Path
+import argparse
+
+
+def create_argument_parser() -> argparse.ArgumentParser:
+    """Return an argument parser configured for CLI use."""
+    parser = argparse.ArgumentParser(description="ShowUp AI Content Generator")
+    parser.add_argument(
+        "--csv_file",
+        default="data/sample_input.csv",
+        help="Path to the CSV file containing lesson data",
+    )
+    parser.add_argument(
+        "--course_name",
+        default="Introduction to Academic Grit",
+        help="Name of the course",
+    )
+    parser.add_argument(
+        "--learner_profile",
+        default="A high school student preparing for college.",
+        help="Description of the target learner",
+    )
+    parser.add_argument(
+        "--log_level",
+        default="INFO",
+        help="Logging level (e.g. INFO or DEBUG)",
+    )
+    parser.add_argument(
+        "--modules",
+        nargs="+",
+        help="Optional list of modules to process",
+    )
+    parser.add_argument(
+        "--phase",
+        choices=["plan", "refine", "generate", "compare", "review", "finalize"],
+        help="Optional workflow phase to execute",
+    )
+    return parser
 
 
 def get_project_root() -> Path:

--- a/simplified_workflow/workflow.py
+++ b/simplified_workflow/workflow.py
@@ -29,6 +29,8 @@ from simplified_workflow.rag_system.cache_manager import cache
 from simplified_workflow.rag_system.textbook_vector_db import get_vector_db
 from simplified_workflow.rag_system.ingest_textbook import extract_text_from_file
 import hashlib
+# Shared parser
+from showup_core.config import create_argument_parser
 # Batch processing functionality removed as per requirement
 from .output_manager import save_as_markdown, create_output_directory, save_generation_summary, save_workflow_log
 
@@ -1209,22 +1211,12 @@ def run_workflow(csv_path: str, course_name: str, learner_profile: str,
         }
 
 if __name__ == "__main__":
-    import argparse
-    
-    # Parse command line arguments
-    parser = argparse.ArgumentParser(description="Run simplified workflow for content generation")
-    parser.add_argument("csv_path", help="Path to the CSV file")
-    parser.add_argument("course_name", help="Name of the course")
-    parser.add_argument("learner_profile", help="Description of the target learner")
-    parser.add_argument("--modules", nargs="+", help="List of modules to process (optional)")
-    parser.add_argument("--phase", choices=["generate", "compare", "review", "finalize"],
-                        help="Optional workflow phase to execute (default: all phases)")
-    
+    parser = create_argument_parser()
     args = parser.parse_args()
     
     # Run the workflow
     asyncio.run(main(
-        args.csv_path,
+        args.csv_file,
         args.course_name,
         args.learner_profile,
         selected_modules=args.modules,


### PR DESCRIPTION
## Summary
- create `create_argument_parser` in `showup_core.config`
- use shared parser in `main.py` to supply defaults and logging level
- use shared parser in `simplified_workflow.workflow` CLI entry

## Testing
- `black showup_core/config.py main.py simplified_workflow/workflow.py`


------
https://chatgpt.com/codex/tasks/task_b_68749393af6483269f93731cb054d1c9