### PR TITLE
Add audio and video placeholder classes

### DIFF
--- a/showup_tools/models/generation_output.py
+++ b/showup_tools/models/generation_output.py
@@ -193,6 +193,28 @@ class ImagePlaceholder(BaseModel):
     placement_suggestion: Optional[str] = None
 
 
+class AudioPlaceholder(BaseModel):
+    """Placeholder for an audio file."""
+
+    block_type: Literal['audio_placeholder']
+    concept_to_illustrate: str
+    description: str
+    audio_duration_seconds: int
+    caption: Optional[str] = None
+    placement_suggestion: Optional[str] = None
+
+
+class VideoPlaceholder(BaseModel):
+    """Placeholder for a video file."""
+
+    block_type: Literal['video_placeholder']
+    concept_to_illustrate: str
+    description: str
+    video_duration_seconds: int
+    caption: Optional[str] = None
+    placement_suggestion: Optional[str] = None
+
+
 AnyBlock = Annotated[
     Union[
         LessonMetadata,
@@ -208,6 +230,8 @@ AnyBlock = Annotated[
         DiagramPlaceholder,
         FlowchartPlaceholder,
         ImagePlaceholder,
+        AudioPlaceholder,
+        VideoPlaceholder,
     ],
     Field(discriminator='block_type')
 ]


### PR DESCRIPTION
## Summary
- add audio and video placeholder models
- include them in `AnyBlock` union

## Testing
- `black showup_tools/models/generation_output.py`
- `isort showup_tools/models/generation_output.py`

------
https://chatgpt.com/codex/tasks/task_b_687499ffa74483268156a4809104ecf1