### PR TITLE
Update PlanModel blocks

### DIFF
--- a/showup_tools/block_library.py
+++ b/showup_tools/block_library.py
@@ -79,21 +79,34 @@ BLOCK_LIBRARY = {
         "fields": {
             "concept_to_illustrate": "str",
             "description": "str",
-            "caption": "Optional[str]",
-            "placement_suggestion": "Optional[str]",
         }
     },
     "flowchart_placeholder": {
         "fields": {
             "process_name": "str",
             "description": "str",
-            "caption": "Optional[str]",
-            "placement_suggestion": "Optional[str]",
         }
     },
     "image_placeholder": {
         "fields": {
             "description": "str",
+            "caption": "Optional[str]",
+        }
+    },
+    "audio_placeholder": {
+        "fields": {
+            "topic": "str",
+            "description": "str",
+            "suggested_duration_seconds": "Optional[int]",
+            "caption": "Optional[str]",
+            "placement_suggestion": "Optional[str]",
+        }
+    },
+    "video_placeholder": {
+        "fields": {
+            "topic": "str",
+            "description": "str",
+            "suggested_duration_seconds": "int",
             "caption": "Optional[str]",
             "placement_suggestion": "Optional[str]",
         }

--- a/showup_tools/models/__init__.py
+++ b/showup_tools/models/__init__.py
@@ -18,6 +18,8 @@ from .generation_output import (
     DiagramPlaceholder,
     FlowchartPlaceholder,
     ImagePlaceholder,
+    AudioPlaceholder,
+    VideoPlaceholder,
     PlanModel,
 )
 
@@ -41,5 +43,7 @@ __all__ = [
     'DiagramPlaceholder',
     'FlowchartPlaceholder',
     'ImagePlaceholder',
+    'AudioPlaceholder',
+    'VideoPlaceholder',
     'PlanModel',
 ]

--- a/showup_tools/models/generation_output.py
+++ b/showup_tools/models/generation_output.py
@@ -123,7 +123,7 @@ class ListBlock(BaseModel):
     """A numbered or bulleted list."""
 
     block_type: Literal['list_block']
-    list_type: str
+    list_type: Literal['numbered', 'bulleted']
     heading: Optional[str] = None
     items_summary: List[str]
 
@@ -170,8 +170,6 @@ class DiagramPlaceholder(BaseModel):
     block_type: Literal['diagram_placeholder']
     concept_to_illustrate: str
     description: str
-    caption: Optional[str] = None
-    placement_suggestion: Optional[str] = None
 
 
 class FlowchartPlaceholder(BaseModel):
@@ -180,8 +178,6 @@ class FlowchartPlaceholder(BaseModel):
     block_type: Literal['flowchart_placeholder']
     process_name: str
     description: str
-    caption: Optional[str] = None
-    placement_suggestion: Optional[str] = None
 
 
 class ImagePlaceholder(BaseModel):
@@ -190,16 +186,15 @@ class ImagePlaceholder(BaseModel):
     block_type: Literal['image_placeholder']
     description: str
     caption: Optional[str] = None
-    placement_suggestion: Optional[str] = None
 
 
 class AudioPlaceholder(BaseModel):
     """Placeholder for an audio file."""
 
     block_type: Literal['audio_placeholder']
-    concept_to_illustrate: str
+    topic: str
     description: str
-    audio_duration_seconds: int
+    suggested_duration_seconds: Optional[int] = None
     caption: Optional[str] = None
     placement_suggestion: Optional[str] = None
 
@@ -208,9 +203,9 @@ class VideoPlaceholder(BaseModel):
     """Placeholder for a video file."""
 
     block_type: Literal['video_placeholder']
-    concept_to_illustrate: str
+    topic: str
     description: str
-    video_duration_seconds: int
+    suggested_duration_seconds: int
     caption: Optional[str] = None
     placement_suggestion: Optional[str] = None
 


### PR DESCRIPTION
## Summary
- align `generation_output.PlanModel` with lesson planner schema
- export audio/video placeholder models
- sync block library with updated block definitions

## Testing
- `python -m py_compile showup_tools/models/generation_output.py showup_tools/models/__init__.py showup_tools/block_library.py`

------
https://chatgpt.com/codex/tasks/task_b_6874a6e6b9c0832690a5820072cb5125