### PR TITLE
Fix refine prompt PlanModel instructions

### DIFF
--- a/prompts/planning/plan_refine_prompt.txt
+++ b/prompts/planning/plan_refine_prompt.txt
@@ -12,5 +12,13 @@ Initial Plan:
 Critique:
 {{critique}}
 
-Respond only with JSON:
-{"content_blocks": [{...}]}
+Respond only with JSON. The output must be a complete `PlanModel` object
+including the required top-level fields `content_title`, `target_audience`, and
+`estimated_word_count`.
+Example structure:
+{
+  "content_title": "...",
+  "target_audience": "...",
+  "estimated_word_count": 1200,
+  "content_blocks": [{...}]
+}


### PR DESCRIPTION
## Summary
- clarify that the refinement stage must output a full PlanModel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6874b242359883268f278a9d697e509f