### PR TITLE
Align Pydantic Plan schema with prompts

### DIFF
--- a/prompts/planning/plan_critique_prompt.txt
+++ b/prompts/planning/plan_critique_prompt.txt
@@ -11,4 +11,4 @@ Learner Profile:
 Plan:
 {{initial_plan}}
 
-Critique:
+Respond with your critique text only. Do not include any JSON or extra formatting.

--- a/prompts/planning/plan_refine_prompt.txt
+++ b/prompts/planning/plan_refine_prompt.txt
@@ -1,4 +1,4 @@
-You are an expert instructional designer. Using the learner profile and critique, improve the initial plan. Use only block types from the library. Ensure the plan begins with `lesson_metadata`, includes `image_placeholder` blocks to break up long text, and omit `learning_objectives` and `key_takeaways` blocks (they will be added later).
+You are an expert instructional designer. Using the learner profile and critique, improve the initial plan. Use only block types from the library. Ensure the plan begins with `lesson_metadata`, includes `image_placeholder` blocks to break up long text, and omit `learning_objectives` and `key_takeaways` blocks (they will be added later). The revised JSON **must** include the top-level fields `content_title`, `target_audience`, and `estimated_word_count` even if the values are unchanged from the initial plan.
 
 Block Library:
 {{block_library}}
@@ -12,13 +12,26 @@ Initial Plan:
 Critique:
 {{critique}}
 
-Respond only with JSON. The output must be a complete `PlanModel` object
-including the required top-level fields `content_title`, `target_audience`, and
-`estimated_word_count`.
-Example structure:
+Respond only with JSON. Provide the revised plan as a single JSON object at the root level (do not wrap it in a `revised_plan` key). The object must match this schema exactly:
+
+```
 {
-  "content_title": "...",
-  "target_audience": "...",
-  "estimated_word_count": 1200,
-  "content_blocks": [{...}]
+  "content_title": "string",
+  "target_audience": "string",
+  "estimated_word_count": integer,
+  "content_blocks": [block objects from the library]
 }
+```
+
+Example of the correct root structure:
+
+```
+{
+  "content_title": "<carry over or updated>",
+  "target_audience": "<carry over or updated>",
+  "estimated_word_count": 1200,
+  "content_blocks": [
+    {"block_type": "lesson_metadata", "title": "...", "module_id": "..."}
+  ]
+}
+```

--- a/showup_tools/block_library.py
+++ b/showup_tools/block_library.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Literal
+import json
 
 from pydantic import BaseModel, create_model, ValidationError
-from .models import PlanModel
 
 BLOCK_LIBRARY = {
     "lesson_metadata": {
@@ -134,8 +134,9 @@ def _parse_type(type_str: str):
 
     # handle union like 'numbered' | 'bulleted'
     if "|" in type_str and "'" in type_str:
-        # treat simple union of string literals as plain str
-        py_type = str
+        # parse union of string literals into Literal
+        options = [part.strip().strip("'") for part in type_str.split("|")]
+        py_type = Literal[tuple(options)]  # type: ignore[arg-type]
     elif type_str.startswith("List[") and type_str.endswith("]"):
         inner = _parse_type(type_str[len("List["):-1])
         py_type = List[inner]  # type: ignore[arg-type]
@@ -168,21 +169,45 @@ def build_pydantic_models():
     BlockUnion = Union[tuple(models.values())]
     PlanModel = create_model(
         "PlanModel",
+        content_title=(str, ...),
+        target_audience=(str, ...),
+        estimated_word_count=(int, ...),
         content_blocks=(List[BlockUnion], ...),
     )
 
     return models, PlanModel
 
 
-BLOCK_MODELS, _ = build_pydantic_models()
+BLOCK_MODELS, PlanModel = build_pydantic_models()
+
+
+def _coerce_plan_types(obj: Dict[str, Any]) -> Dict[str, Any]:
+    """Coerce common type mismatches before validation."""
+    if "estimated_word_count" in obj and isinstance(obj["estimated_word_count"], str):
+        if obj["estimated_word_count"].isdigit():
+            obj["estimated_word_count"] = int(obj["estimated_word_count"])
+    for block in obj.get("content_blocks", []):
+        if block.get("block_type") == "process_steps":
+            for step in block.get("steps", []):
+                if isinstance(step.get("step_number"), int):
+                    step["step_number"] = str(step["step_number"])
+    return obj
 
 
 def validate_plan(data: str | dict):
     """Validate a plan JSON string or object."""
     try:
         if isinstance(data, str):
-            return PlanModel.model_validate_json(data)
-        return PlanModel.model_validate(data)
+            obj = json.loads(data)
+        else:
+            obj = data
+        obj = _coerce_plan_types(obj)
+        return PlanModel.model_validate(obj)
     except ValidationError as e:
-        raise ValueError(str(e))
+        details = []
+        for err in e.errors():
+            loc = ".".join(str(p) for p in err["loc"])
+            msg = err["msg"]
+            details.append(f"{loc}: {msg}")
+        raise ValueError("; ".join(details))
 

--- a/showup_tools/models/__init__.py
+++ b/showup_tools/models/__init__.py
@@ -21,8 +21,8 @@ from .generation_output import (
     ImagePlaceholder,
     AudioPlaceholder,
     VideoPlaceholder,
-    PlanModel,
 )
+from ..block_library import PlanModel
 
 __all__ = [
     'SentimentAnalysis',

--- a/showup_tools/models/generation_output.py
+++ b/showup_tools/models/generation_output.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 from typing import List, Literal, Dict, Any, Optional, Union, Annotated
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
-class SentimentAnalysis(BaseModel):
+
+class StrictBaseModel(BaseModel):
+    """Base model that forbids extra fields."""
+
+    model_config = ConfigDict(extra="forbid")
+
+class SentimentAnalysis(StrictBaseModel):
     """Detailed sentiment analysis of text."""
 
     overall_sentiment: Literal["Positive", "Negative", "Neutral"] = Field(
@@ -13,7 +19,7 @@ class SentimentAnalysis(BaseModel):
         ..., description="A sentiment score from -1.0 (very negative) to 1.0 (very positive)."
     )
 
-class DetectedAIPattern(BaseModel):
+class DetectedAIPattern(StrictBaseModel):
     """Represents a detected AI pattern category and its matches."""
 
     category: str = Field(
@@ -23,13 +29,13 @@ class DetectedAIPattern(BaseModel):
         default_factory=list, description="List of specific text snippets that matched the pattern."
     )
 
-class DetectedAIPhrase(BaseModel):
+class DetectedAIPhrase(StrictBaseModel):
     """Represents a specific AI phrase detected in the content."""
 
     phrase: str = Field(..., description="The specific AI phrase detected.")
     count: int = Field(..., description="Number of times this phrase was detected.")
 
-class TextSegmentAnalysis(BaseModel):
+class TextSegmentAnalysis(StrictBaseModel):
     """Consolidated analysis results for a text segment."""
 
     sentiment: SentimentAnalysis = Field(..., description="Sentiment analysis for this segment.")
@@ -42,7 +48,7 @@ class TextSegmentAnalysis(BaseModel):
         description="AI pattern categories detected in this segment, referencing 'ai_patterns.json'.",
     )
 
-class GeneratedContentBlock(BaseModel):
+class GeneratedContentBlock(StrictBaseModel):
     """Represents a single dynamic content block within the generated output."""
 
     block_id: str = Field(..., description="A unique identifier for this content block.")
@@ -58,7 +64,7 @@ class GeneratedContentBlock(BaseModel):
         description="Additional metadata specific to this block (e.g., source, generation parameters).",
     )
 
-class DynamicContentGenerationResult(BaseModel):
+class DynamicContentGenerationResult(StrictBaseModel):
     """Structured output from the dynamic block template generation phase."""
 
     document_id: str = Field(..., description="Unique identifier for the entire generated document.")
@@ -77,7 +83,7 @@ class DynamicContentGenerationResult(BaseModel):
     )
 
 
-class LessonMetadata(BaseModel):
+class LessonMetadata(StrictBaseModel):
     """Metadata about the lesson."""
 
     block_type: Literal['lesson_metadata']
@@ -87,14 +93,14 @@ class LessonMetadata(BaseModel):
     purpose: Optional[str] = None
 
 
-class LearningObjectives(BaseModel):
+class LearningObjectives(StrictBaseModel):
     """Learning objectives for the lesson."""
 
     block_type: Literal['learning_objectives']
     objectives: List[str]
 
 
-class Introduction(BaseModel):
+class Introduction(StrictBaseModel):
     """Introduction content summary."""
 
     block_type: Literal['introduction']
@@ -102,7 +108,7 @@ class Introduction(BaseModel):
     hook_suggestion: Optional[str] = None
 
 
-class SectionHeading(BaseModel):
+class SectionHeading(StrictBaseModel):
     """Heading for a section."""
 
     block_type: Literal['section_heading']
@@ -110,7 +116,7 @@ class SectionHeading(BaseModel):
     title: str
 
 
-class ExplanatoryText(BaseModel):
+class ExplanatoryText(StrictBaseModel):
     """Explanatory text covering a topic."""
 
     block_type: Literal['explanatory_text']
@@ -119,7 +125,7 @@ class ExplanatoryText(BaseModel):
     tone_suggestion: Optional[str] = None
 
 
-class ListBlock(BaseModel):
+class ListBlock(StrictBaseModel):
     """A numbered or bulleted list."""
 
     block_type: Literal['list_block']
@@ -128,7 +134,7 @@ class ListBlock(BaseModel):
     items_summary: List[str]
 
 
-class ExampleAnalysis(BaseModel):
+class ExampleAnalysis(StrictBaseModel):
     """Analysis of an example or scenario."""
 
     block_type: Literal['example_analysis']
@@ -139,14 +145,14 @@ class ExampleAnalysis(BaseModel):
     explanation_points: List[str]
 
 
-class Step(BaseModel):
+class Step(StrictBaseModel):
     """Single step within a ``process_steps`` block."""
 
     step_number: str
     description: str
 
 
-class ProcessSteps(BaseModel):
+class ProcessSteps(StrictBaseModel):
     """Steps describing a process."""
 
     block_type: Literal['process_steps']
@@ -155,7 +161,7 @@ class ProcessSteps(BaseModel):
     steps: List[Step]
 
 
-class ReflectionPrompt(BaseModel):
+class ReflectionPrompt(StrictBaseModel):
     """Questions prompting reflection."""
 
     block_type: Literal['reflection_prompt']
@@ -164,14 +170,14 @@ class ReflectionPrompt(BaseModel):
     context_setting: Optional[str] = None
 
 
-class KeyTakeaways(BaseModel):
+class KeyTakeaways(StrictBaseModel):
     """Key takeaways from the lesson."""
 
     block_type: Literal['key_takeaways']
     points: List[str]
 
 
-class DiagramPlaceholder(BaseModel):
+class DiagramPlaceholder(StrictBaseModel):
     """Placeholder for a diagram."""
 
     block_type: Literal['diagram_placeholder']
@@ -179,7 +185,7 @@ class DiagramPlaceholder(BaseModel):
     description: str
 
 
-class FlowchartPlaceholder(BaseModel):
+class FlowchartPlaceholder(StrictBaseModel):
     """Placeholder for a flowchart."""
 
     block_type: Literal['flowchart_placeholder']
@@ -187,7 +193,7 @@ class FlowchartPlaceholder(BaseModel):
     description: str
 
 
-class ImagePlaceholder(BaseModel):
+class ImagePlaceholder(StrictBaseModel):
     """Placeholder for an image."""
 
     block_type: Literal['image_placeholder']
@@ -195,7 +201,7 @@ class ImagePlaceholder(BaseModel):
     caption: Optional[str] = None
 
 
-class AudioPlaceholder(BaseModel):
+class AudioPlaceholder(StrictBaseModel):
     """Placeholder for an audio file."""
 
     block_type: Literal['audio_placeholder']
@@ -206,7 +212,7 @@ class AudioPlaceholder(BaseModel):
     placement_suggestion: Optional[str] = None
 
 
-class VideoPlaceholder(BaseModel):
+class VideoPlaceholder(StrictBaseModel):
     """Placeholder for a video file."""
 
     block_type: Literal['video_placeholder']
@@ -239,9 +245,12 @@ AnyBlock = Annotated[
 ]
 
 
-class PlanModel(BaseModel):
+class PlanModel(StrictBaseModel):
     """Represents the entire lesson plan structure."""
 
+    # Deprecated: The active PlanModel is dynamically built from
+    # ``showup_tools.block_library.BLOCK_LIBRARY``. This static class
+    # remains for type hints only and may drift from the prompts.
     content_title: str
     target_audience: str
     estimated_word_count: int

--- a/showup_tools/prompts/plan_critique_prompt.txt
+++ b/showup_tools/prompts/plan_critique_prompt.txt
@@ -11,4 +11,4 @@ Learner Profile:
 Plan:
 {{initial_plan}}
 
-Critique:
+Respond with your critique text only. Do not include any JSON or extra formatting.

--- a/showup_tools/prompts/plan_refine_prompt.txt
+++ b/showup_tools/prompts/plan_refine_prompt.txt
@@ -1,4 +1,4 @@
-You are an expert instructional designer. Using the learner profile and critique, improve the initial plan. Use only block types from the library. Ensure the plan begins with `lesson_metadata`, includes `image_placeholder` blocks to break up long text, and omit `learning_objectives` and `key_takeaways` blocks (they will be added later).
+You are an expert instructional designer. Using the learner profile and critique, improve the initial plan. Use only block types from the library. Ensure the plan begins with `lesson_metadata`, includes `image_placeholder` blocks to break up long text, and omit `learning_objectives` and `key_takeaways` blocks (they will be added later). The revised JSON must include the top-level fields `content_title`, `target_audience`, and `estimated_word_count` even if unchanged from the initial plan.
 
 Block Library:
 {{block_library}}
@@ -12,5 +12,4 @@ Initial Plan:
 Critique:
 {{critique}}
 
-Respond only with JSON:
-{"content_blocks": [{...}]}
+Respond only with JSON. Provide the revised plan as a single JSON object at the root level (do not wrap it in a `revised_plan` key). The object must include `content_title`, `target_audience`, `estimated_word_count`, and `content_blocks`.

--- a/templates/prompt_templates.json
+++ b/templates/prompt_templates.json
@@ -8,9 +8,9 @@
     },
     "refinement_stage": {
       "id": "critic_v1",
-      "description": "Critiques an initial plan against a learner profile and produces a revised, improved plan.",
-      "_comment": "This prompt requires the following placeholders: {initial_plan_json}, {learner_profile}",
-      "template": "You are an expert instructional designer and curriculum specialist, reviewing a video script plan. Your task is to critique the following plan and then provide a revised, improved version that is more engaging and effective for the target audience.\n\n### EVALUATION CRITERIA ###\n1. **Engagement:** Is the language, pacing, and content interesting and relatable for the target audience?\n2. **Clarity:** Are complex concepts explained in a simple, easy-to-understand manner?\n3. **Completeness:** Does the plan cover all essential aspects of the topic logically?\n\n### LEARNER PROFILE ###\n{learner_profile}\n\n### PLAN TO REVIEW ###\n{initial_plan_json}\n\n### YOUR TASK ###\nProvide your response as a single, valid JSON object. The object must have two keys:\n1. `critique`: A string containing your detailed feedback on the original plan, referencing the evaluation criteria.\n2. `revised_plan`: The full, improved plan in the original JSON format, incorporating your suggested changes."
+      "description": "Critiques an initial plan and then generates a revised plan in a two-step process.",
+      "_comment": "This stage uses two prompts: plan_critique_prompt (plain text critique) and plan_refine_prompt (root-level PlanModel JSON).",
+      "template": "The critique prompt instructs the AI to provide plain text feedback only. The refine prompt then asks for the full revised plan as a single JSON object with top-level fields `content_title`, `target_audience`, `estimated_word_count`, and `content_blocks` without any wrapping key."
     },
     "generation_stage": {
       "id": "generator_from_plan_v1",


### PR DESCRIPTION
## Summary
- enforce strict PlanModel validation by coercing common types
- expand error messages with precise field details
- clarify required top-level fields in plan_refine_prompt
- dynamically build `PlanModel` from the block library
- refine prompts and template descriptions for the two-step critique/refine flow

## Testing
- `python -m py_compile showup_tools/block_library.py showup_tools/models/generation_output.py showup_tools/models/__init__.py`
- `python -m compileall showup_tools/block_library.py showup_tools/models/generation_output.py`


------
https://chatgpt.com/codex/tasks/task_b_6874b5425a6c8326ac80b561dc50645d