### PR TITLE
Improve generation tag handling

### DIFF
--- a/prompts/generation/generation_prompt.txt
+++ b/prompts/generation/generation_prompt.txt
@@ -1,11 +1,13 @@
-You are generating lesson content block by block.
-The entire lesson should be roughly {{word_count}} words in total.
+You are generating lesson content. The assembled lesson should be roughly {{word_count}} words in total.
 Use Markdown formatting when appropriate.
+
+If generating a single block, you will receive the block JSON in {{block}} and a short {{instruction}} describing how to expand it.
+If generating the entire lesson, you will receive the complete plan JSON in {{final_plan}}. Follow it closely.
+
+Important: Wrap **all** of your output inside `<educational_content>` tags and do not include any commentary outside the tags.
 
 Block details:
 {{block}}
 
 Instruction:
 {{instruction}}
-
-Write only the content for this block.

--- a/prompts/system/ai_editor_system_message.txt
+++ b/prompts/system/ai_editor_system_message.txt
@@ -1,1 +1,7 @@
 You are an expert editor specializing in making AI-generated content more human-like and natural. You excel at identifying patterns typical of AI writing and transforming them into authentic, engaging content that resonates with specific target audiences.
+
+Always wrap the entire generated output within `<educational_content>` tags like this:
+<educational_content>
+Your content here
+</educational_content>
+Do not include any commentary outside these tags.

--- a/showup_tools/content_generator.py
+++ b/showup_tools/content_generator.py
@@ -169,6 +169,7 @@ async def generate_content(variables: Dict[str, str], template: str, settings: O
             )
 
         logger.info(f"Successfully generated content ({len(content)} characters)")
+        verify_educational_content_tags(content)
         return content
 
     except Exception as e:
@@ -186,6 +187,7 @@ async def generate_three_versions_from_plan(final_plan: Dict[str, Any], ui_setti
         ui_settings = {}
 
     use_dynamic = ui_settings.get("use_dynamic_blocks", True)
+    system_prompt = load_prompt("system/ai_editor_system_message")
 
     prompt_template = load_prompt("generation/generation_prompt")
     if not prompt_template:
@@ -221,8 +223,10 @@ async def generate_three_versions_from_plan(final_plan: Dict[str, Any], ui_setti
                     model=model,
                     frequency_penalty=freq_pen,
                     presence_penalty=pres_pen,
+                    system_prompt=system_prompt,
                     task_type="content_generation",
                 )
+                verify_educational_content_tags(result)
                 parts.append(result.strip())
             return "\n\n".join(parts)
     else:
@@ -237,13 +241,18 @@ async def generate_three_versions_from_plan(final_plan: Dict[str, Any], ui_setti
                 model=model,
                 frequency_penalty=freq_pen,
                 presence_penalty=pres_pen,
+                system_prompt=system_prompt,
                 task_type="content_generation",
             )
+            verify_educational_content_tags(result)
             return result.strip()
 
     temperatures = [0.3, 0.5, 1.0]
     tasks = [asyncio.create_task(generate_version(t)) for t in temperatures]
     versions = await asyncio.gather(*tasks)
+
+    for v in versions:
+        verify_educational_content_tags(v)
 
     logger.info("Completed generation of all three versions from plan")
     return list(versions)
@@ -276,6 +285,15 @@ def extract_educational_content(content: str) -> str:
         # If tags not found, return the original content
         logger.warning("Educational content tags not found, returning original content")
         return content
+
+def verify_educational_content_tags(content: str) -> bool:
+    """Check that the generated content includes <educational_content> tags."""
+    start_tag = "<educational_content>"
+    end_tag = "</educational_content>"
+    if start_tag in content and end_tag in content:
+        return True
+    logger.warning("<educational_content> tags missing from generated output")
+    return False
 
 from pathlib import Path
 

--- a/showup_tools/prompts/generation_prompt.txt
+++ b/showup_tools/prompts/generation_prompt.txt
@@ -1,11 +1,13 @@
-You are generating lesson content block by block.
-The entire lesson should be roughly {{word_count}} words in total.
+You are generating lesson content. The assembled lesson should be roughly {{word_count}} words in total.
 Use Markdown formatting when appropriate.
+
+If generating a single block, you will receive the block JSON in {{block}} and a short {{instruction}} describing how to expand it.
+If generating the entire lesson, you will receive the complete plan JSON in {{final_plan}}. Follow it closely.
+
+Important: Wrap **all** of your output inside `<educational_content>` tags and do not include any commentary outside the tags.
 
 Block details:
 {{block}}
 
 Instruction:
 {{instruction}}
-
-Write only the content for this block.


### PR DESCRIPTION
## Summary
- ensure prompts mention `<educational_content>` tags and support `{{final_plan}}`
- add instructions to ai editor system message
- use system prompt when generating from plan
- verify presence of `<educational_content>` tags after generation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6874ba21a07483269d5c4c1b14c5f1ee