### PR TITLE
Improve parsing reliability

### DIFF
--- a/prompts/review/content_comparison_prompt.txt
+++ b/prompts/review/content_comparison_prompt.txt
@@ -2,22 +2,22 @@ You are tasked with analyzing three generations of content created from the same
 
 1. Review the target learner information:
 <target_learner>
-{target_learner}
+{{target_learner}}
 </target_learner>
 
 2. Understand the context:
 <context>
-{educational_context}
+{{educational_context}}
 </context>
 
 3. Familiarize yourself with the template structure:
 <template>
-{template_context}
+{{template_context}}
 </template>
 
 4. Examine the three generations of content:
 <generations>
-{formatted_generations}
+{{formatted_generations}}
 </generations>
 
 5. Analyze the generations:
@@ -51,5 +51,7 @@ Your complete response should be structured as follows:
 <explanation>
 [Insert your brief explanation here]
 </explanation>
+
+IMPORTANT: Do not include any text outside the <best_version> and <explanation> tags. Any extraneous output will cause parsing errors.
 
 Remember to focus on creating content that is most suitable for the target learner while adhering to the given template and context.

--- a/prompts/review/content_review_prompt.txt
+++ b/prompts/review/content_review_prompt.txt
@@ -3,13 +3,13 @@ You are an experienced educational content editor tasked with reviewing and maki
 First, carefully review the target learner profile:
 
 <target_learner_profile>
-{target_learner_profile}
+{{target_learner_profile}}
 </target_learner_profile>
 
 Now, review the content that needs to be edited:
 
 <content>
-{content}
+{{content}}
 </content>
 
 Your task is to make minor edits to the content that will remove barriers to learning for the target learner profile. Follow these guidelines:
@@ -34,5 +34,7 @@ After reviewing and editing the content, provide your output in the following fo
 <edit_summary>
 [Provide a brief summary of the changes you made and why they were necessary for the target learner profile. Limit this to 3-5 bullet points.]
 </edit_summary>
+
+IMPORTANT: Do not include any text outside the <edited_content> and <edit_summary> tags. Any extraneous output will cause parsing errors.
 
 Remember, the goal is to make the content more accessible to the target learner without drastically changing its substance or going overboard with edits.

--- a/showup_tools/content_comparator.py
+++ b/showup_tools/content_comparator.py
@@ -215,10 +215,10 @@ def _create_comparison_prompt(generations: List[str],
         logger.warning("Template loader not available, using default template")
 
         template = load_prompt('review/content_comparison_prompt')
-        prompt = template.replace('{target_learner}', target_learner)
-        prompt = prompt.replace('{educational_context}', educational_context)
-        prompt = prompt.replace('{template_context}', template_context)
-        prompt = prompt.replace('{formatted_generations}', formatted_generations)
+        prompt = template.replace('{{target_learner}}', target_learner)
+        prompt = prompt.replace('{{educational_context}}', educational_context)
+        prompt = prompt.replace('{{template_context}}', template_context)
+        prompt = prompt.replace('{{formatted_generations}}', formatted_generations)
 
         logger.info(f"Created comparison prompt from file ({len(prompt)} characters)")
         return prompt
@@ -235,24 +235,28 @@ def _extract_comparison_results(result: str) -> Tuple[str, str]:
     """
     logger.info("Extracting comparison results")
     
-    # Extract best version
-    best_version_match = re.search(r'<best_version>(.*?)</best_version>', 
-                                  result, re.DOTALL)
-    
-    # Extract explanation
-    explanation_match = re.search(r'<explanation>(.*?)</explanation>', 
-                                 result, re.DOTALL)
-    
-    if best_version_match:
-        best_version = best_version_match.group(1).strip()
-    else:
-        logger.warning("Best version tags not found in comparison result")
-        best_version = result
-    
-    if explanation_match:
-        explanation = explanation_match.group(1).strip()
-    else:
-        logger.warning("Explanation tags not found in comparison result")
-        explanation = "No explanation provided."
-    
-    return best_version, explanation
+    pattern = re.compile(
+        r'^\s*<best_version>(.*?)</best_version>\s*<explanation>(.*?)</explanation>\s*$',
+        re.DOTALL,
+    )
+    match = pattern.fullmatch(result)
+
+    if match:
+        best_version = match.group(1).strip()
+        explanation = match.group(2).strip()
+        return best_version, explanation
+
+    errors = []
+    if not re.search(r'<best_version>.*?</best_version>', result, re.DOTALL):
+        errors.append("Expected <best_version> not found.")
+    if not re.search(r'<explanation>.*?</explanation>', result, re.DOTALL):
+        errors.append("Expected <explanation> not found.")
+
+    cleaned = re.sub(r'<best_version>.*?</best_version>', '', result, flags=re.DOTALL)
+    cleaned = re.sub(r'<explanation>.*?</explanation>', '', cleaned, flags=re.DOTALL)
+    if cleaned.strip():
+        errors.append("Extraneous text detected outside expected tags.")
+
+    error_msg = " ".join(errors) if errors else "Unexpected format in comparison result."
+    logger.error(error_msg)
+    raise ValueError(error_msg)

--- a/showup_tools/content_reviewer.py
+++ b/showup_tools/content_reviewer.py
@@ -153,8 +153,8 @@ def _create_review_prompt(content: str, target_learner_profile: str) -> str:
         logger.warning("Template loader not available, using default template")
 
         template = load_prompt('review/content_review_prompt')
-        prompt = template.replace('{content}', content)
-        prompt = prompt.replace('{target_learner_profile}', target_learner_profile)
+        prompt = template.replace('{{content}}', content)
+        prompt = prompt.replace('{{target_learner_profile}}', target_learner_profile)
 
         logger.info(f"Created review prompt from file ({len(prompt)} characters)")
         return prompt
@@ -171,24 +171,28 @@ def _extract_review_results(result: str) -> Tuple[str, str]:
     """
     logger.info("Extracting review results")
     
-    # Extract edited content
-    edited_content_match = re.search(r'<edited_content>(.*?)</edited_content>', 
-                                    result, re.DOTALL)
-    
-    # Extract edit summary
-    edit_summary_match = re.search(r'<edit_summary>(.*?)</edit_summary>', 
-                                  result, re.DOTALL)
-    
-    if edited_content_match:
-        edited_content = edited_content_match.group(1).strip()
-    else:
-        logger.warning("Edited content tags not found in review result")
-        edited_content = result
-    
-    if edit_summary_match:
-        edit_summary = edit_summary_match.group(1).strip()
-    else:
-        logger.warning("Edit summary tags not found in review result")
-        edit_summary = "No edit summary provided."
-    
-    return edited_content, edit_summary
+    pattern = re.compile(
+        r'^\s*<edited_content>(.*?)</edited_content>\s*<edit_summary>(.*?)</edit_summary>\s*$',
+        re.DOTALL,
+    )
+    match = pattern.fullmatch(result)
+
+    if match:
+        edited_content = match.group(1).strip()
+        edit_summary = match.group(2).strip()
+        return edited_content, edit_summary
+
+    errors = []
+    if not re.search(r'<edited_content>.*?</edited_content>', result, re.DOTALL):
+        errors.append("Expected <edited_content> not found.")
+    if not re.search(r'<edit_summary>.*?</edit_summary>', result, re.DOTALL):
+        errors.append("Expected <edit_summary> not found.")
+
+    cleaned = re.sub(r'<edited_content>.*?</edited_content>', '', result, flags=re.DOTALL)
+    cleaned = re.sub(r'<edit_summary>.*?</edit_summary>', '', cleaned, flags=re.DOTALL)
+    if cleaned.strip():
+        errors.append("Extraneous text detected outside expected tags.")
+
+    error_msg = " ".join(errors) if errors else "Unexpected format in review result."
+    logger.error(error_msg)
+    raise ValueError(error_msg)


### PR DESCRIPTION
## Summary
- enforce consistent placeholder syntax with `{{double_braces}}`
- strengthen instructions in review prompts about required output tags
- update prompt replacement logic to match new syntax
- add strict validation of response tags with clearer errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6874bbf5131c8326a0094b0900185dc2