### PR TITLE
Model config wiring

### DIFF
--- a/config/model_settings.json
+++ b/config/model_settings.json
@@ -1,0 +1,6 @@
+{
+  "generation_model": "claude-3-sonnet-20240620",
+  "comparison_model": "claude-3-sonnet-20240620",
+  "review_model": "claude-3-sonnet-20240620",
+  "lo_kt_model": "claude-3-sonnet-20240620"
+}

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from tkinter import filedialog
 from kivy.uix.progressbar import ProgressBar
 from kivy.clock import Clock
 from kivy.properties import StringProperty, BooleanProperty, NumericProperty
-from showup_core.model_config import DEFAULT_PLANNING_MODEL
+from showup_core.model_config import DEFAULT_PLANNING_MODEL, load_model_config
 from showup_core.config import create_argument_parser
 
 import asyncio
@@ -229,11 +229,15 @@ class WorkflowApp(App):
                     self.status_message = f"[color=ff8c00]Warning: Handbook file not found at {abs_handbook_path}. Proceeding without handbook.[/color]"
                     abs_handbook_path = ""
 
+        models_cfg = load_model_config()
+
         ui_settings = {
             "use_reference_handbook": bool(abs_handbook_path),
             "reference_handbook_path": abs_handbook_path,
             "selected_model": DEFAULT_PLANNING_MODEL,
-            "initial_generation_model": "claude-3-haiku-20240307",
+            "initial_generation_model": models_cfg["generation_model"],
+            "comparison_model": models_cfg["comparison_model"],
+            "review_model": models_cfg["review_model"],
             "planning_model": DEFAULT_PLANNING_MODEL,
             "refinement_model": DEFAULT_PLANNING_MODEL,
             "planning_max_tokens": 8000,

--- a/showup_core/model_config.py
+++ b/showup_core/model_config.py
@@ -1,6 +1,17 @@
-"""
-Model configuration module for AI API models.
-"""
+"""Model configuration module for AI API models."""
+
+import json
+import pathlib
+
+_CACHE = None
+
+def load_model_config():
+    """Load model configuration from JSON file (cached)."""
+    global _CACHE
+    if _CACHE is None:
+        path = pathlib.Path(__file__).parent.parent / "config" / "model_settings.json"
+        _CACHE = json.loads(path.read_text())
+    return _CACHE
 
 # Available Claude models
 CLAUDE_MODELS = [

--- a/showup_tools/content_comparator.py
+++ b/showup_tools/content_comparator.py
@@ -76,11 +76,7 @@ async def compare_and_combine(generations: List[str],
             # Call Claude API directly (batch processing has been removed from the workflow)
             # Use token limit from UI settings if provided, otherwise use 8000 as default
             token_limit = ui_settings.get('token_limit', 8000) if ui_settings else 8000
-            model = (
-                ui_settings.get('model', 'claude-3-haiku-20240307')
-                if ui_settings
-                else 'claude-3-haiku-20240307'
-            )
+            model = ui_settings['model']
             
             logger.info(f"Using token limit from UI settings: {token_limit}")
             

--- a/showup_tools/content_reviewer.py
+++ b/showup_tools/content_reviewer.py
@@ -63,11 +63,7 @@ async def review_content(content: str, target_learner_profile: str, instance_id:
             # Call Claude API directly (batch processing has been removed from the workflow)
             # Use token limit from UI settings if provided, otherwise fall back to model default
             token_limit = ui_settings.get('token_limit', 4000) if ui_settings else 4000
-            model = (
-                ui_settings.get('model', 'claude-3-haiku-20240307')
-                if ui_settings
-                else 'claude-3-haiku-20240307'
-            )
+            model = ui_settings['model']
             
             logger.info(f"Using token limit from UI settings: {token_limit}")
             

--- a/simplified_workflow/content_comparator.py
+++ b/simplified_workflow/content_comparator.py
@@ -77,11 +77,7 @@ async def compare_and_combine(generations: List[str],
             # Call Claude API directly (batch processing has been removed from the workflow)
             # Use token limit from UI settings if provided, otherwise use 8000 as default
             token_limit = ui_settings.get('token_limit', 8000) if ui_settings else 8000
-            model = (
-                ui_settings.get('model', DEFAULT_MODEL)
-                if ui_settings
-                else DEFAULT_MODEL
-            )
+            model = ui_settings['model']
             
             logger.info(f"Using token limit from UI settings: {token_limit}")
             

--- a/simplified_workflow/content_generator.py
+++ b/simplified_workflow/content_generator.py
@@ -52,7 +52,7 @@ async def generate_content(variables: Dict[str, str], template: str, settings: O
     # Get model from settings - prioritize initial_generation_model if available
     model = settings.get(
         "initial_generation_model",
-        settings.get("selected_model", "claude-3-haiku-20240307"),
+        settings["selected_model"],
     )
 
     # Get template-specific settings if available
@@ -208,7 +208,7 @@ async def generate_three_versions(variables: Dict[str, str], template: str) -> L
     # Get the initial generation model from UI settings
     model = ui_settings.get(
         "initial_generation_model",
-        ui_settings.get("selected_model", "claude-3-haiku-20240307"),
+        ui_settings["selected_model"],
     )
     logger.info(f"Using initial generation model: {model} for three versions generation")
     

--- a/simplified_workflow/content_reviewer.py
+++ b/simplified_workflow/content_reviewer.py
@@ -63,11 +63,7 @@ async def review_content(content: str, target_learner_profile: str, instance_id:
             # Call Claude API directly (batch processing has been removed from the workflow)
             # Use token limit from UI settings if provided, otherwise fall back to model default
             token_limit = ui_settings.get('token_limit', 4000) if ui_settings else 4000
-            model = (
-                ui_settings.get('model', 'claude-3-haiku-20240307')
-                if ui_settings
-                else 'claude-3-haiku-20240307'
-            )
+            model = ui_settings['model']
             
             logger.info(f"Using token limit from UI settings: {token_limit}")
             

--- a/simplified_workflow/learning_sections.py
+++ b/simplified_workflow/learning_sections.py
@@ -4,11 +4,14 @@ import re
 from typing import Tuple
 from showup_core.api_client import generate_with_claude
 from showup_core.utils import load_prompt
+from showup_core.model_config import load_model_config
+
+models_cfg = load_model_config()
 
 logger = logging.getLogger(__name__)
 
 
-async def generate_lo_and_kt_from_content(content: str, model: str = 'claude-3-haiku-20240307', max_tokens: int = 800) -> Tuple[str, str]:
+async def generate_lo_and_kt_from_content(content: str, model: str = models_cfg["lo_kt_model"], max_tokens: int = 800) -> Tuple[str, str]:
     """Generate learning objectives and key takeaways from lesson content."""
     prompt_template = load_prompt('generation/lo_kt_generation_prompt')
     if not prompt_template:


### PR DESCRIPTION
## Summary
- add `config/model_settings.json` for setting models
- implement `load_model_config()` helper
- use `load_model_config()` in the Kivy app to set defaults
- remove hard-coded model fallbacks from generation, comparison, and review
- allow learning section extraction to use configured model

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6874d4c7a4f48326b0ca96ed1d3dccd5