### PR TITLE
Ensure strict word_count use from CSV

### DIFF
--- a/showup_tools/csv_processor.py
+++ b/showup_tools/csv_processor.py
@@ -52,7 +52,12 @@ def read_csv(csv_path: str) -> List[Dict[str, str]]:
         learner_profile_columns = ["Learner Profile", "learner_profile"]
 
         # Word count column variants
-        word_count_columns = ["Target_Word_Count", "Target Word Count", "word_count"]
+        word_count_columns = [
+            "Target_Word_Count",
+            "Target Word Count",
+            "word_count",
+            "Word Count",  # recognize common title-cased column name
+        ]
 
         # Check for learner profile column
         has_profile = any(col in rows[0] for col in learner_profile_columns)

--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -40,11 +40,8 @@ async def run_planning_stage(
     rationale = new_item.get("What is the rationale for this step") or new_item.get(
         "rationale", ""
     )
-    word_count = str(
-        new_item.get("word_count")
-        or config.get("word_count")
-        or ""
-    )
+    # Strictly rely on the CSV value; don't fall back to defaults
+    word_count = str(new_item.get("word_count", ""))
     block_defs = get_block_type_definitions()
     prompt = (
         prompt_template.replace("{{content_outline}}", content_outline)


### PR DESCRIPTION
## Summary
- add "Word Count" header to recognized word_count columns
- rely only on CSV `word_count` value in planning stage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6874e4d3c48483268ccd087bdb238fe3