### PR TITLE
Switch workflow to provider-agnostic AI calls

### DIFF
--- a/showup_core/api_client.py
+++ b/showup_core/api_client.py
@@ -23,6 +23,7 @@ from .model_config import (
     DEFAULT_MODEL,
     DEFAULT_CONTEXT_MODEL,
     DEFAULT_PLANNING_MODEL,
+    get_model_provider,
 )
 
 try:
@@ -681,6 +682,65 @@ def save_api_logs_to_files(prompt: str, response: str, module_number=None, lesso
     logger.info(f"=== COMPLETED SAVING API LOGS: {function_type} ===")
 
 
+async def generate_with_ai(
+    prompt: str,
+    max_tokens: int = 4000,
+    temperature: float = 0.7,
+    model: Optional[str] = None,
+    use_cache: bool = True,
+    task_type: str = "content_generation",
+    system_prompt: str = "",
+    module_number: int = None,
+    lesson_number: int = None,
+    step_number: int = None,
+    frequency_penalty: float = 0.0,
+    presence_penalty: float = 0.0,
+) -> str:
+    provider = get_model_provider(model or DEFAULT_MODEL)
+    if provider == "openai":
+        try:
+            import openai
+
+            api_key = os.getenv("OPENAI_API_KEY")
+            if not api_key:
+                from config.api_keys import OPENAI_API_KEY
+
+                api_key = OPENAI_API_KEY
+            client = openai.OpenAI(api_key=api_key)
+            messages = []
+            if system_prompt:
+                messages.append({"role": "system", "content": system_prompt})
+            messages.append({"role": "user", "content": prompt})
+            response = client.chat.completions.create(
+                model=model,
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                frequency_penalty=frequency_penalty,
+                presence_penalty=presence_penalty,
+            )
+            from .api_utils import extract_response_content
+
+            return extract_response_content(response, client_type="openai")
+        except Exception as e:
+            logger.error(f"OpenAI generation failed: {e}")
+            return f"Error generating content with OpenAI API: {e}"
+    return await generate_with_claude(
+        prompt=prompt,
+        system_prompt=system_prompt,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        model=model,
+        use_cache=use_cache,
+        task_type=task_type,
+        module_number=module_number,
+        lesson_number=lesson_number,
+        step_number=step_number,
+        frequency_penalty=frequency_penalty,
+        presence_penalty=presence_penalty,
+    )
+
+
 async def generate_with_llm(prompt: str, task_type: str = "content_creation",
                       complexity: str = "standard", max_tokens: int = 4000,
                       temperature: float = 0.7, use_cache: bool = True) -> str:
@@ -710,6 +770,7 @@ __all__ = [
     'ApiClient',
     'get_api_client',
     'generate_with_claude',
+    'generate_with_ai',
     'generate_with_llm',
     'PromptTemplateSystem'
 ]

--- a/simplified_workflow/ai_detector.py
+++ b/simplified_workflow/ai_detector.py
@@ -11,7 +11,7 @@ import os
 from typing import Dict, List, Any, Optional, Tuple
 
 # Import from core modules
-from showup_core.api_client import generate_with_claude
+from showup_core.api_client import generate_with_ai
 from .constants import EXCEL_CLARIFICATION
 from showup_core.utils import load_prompt
 
@@ -173,7 +173,7 @@ async def edit_content(content: str, detected_patterns: Dict[str, Any], target_l
         token_limit = int(ui_settings.get("token_limit", 4000)) if ui_settings else 4000
         logger.info(f"Using token limit: {token_limit}")
         
-        result = await generate_with_claude(
+        result = await generate_with_ai(
             prompt=prompt,
             system_prompt=system_prompt,
             max_tokens=token_limit,

--- a/simplified_workflow/content_comparator.py
+++ b/simplified_workflow/content_comparator.py
@@ -10,7 +10,7 @@ import asyncio
 from typing import Dict, List, Any, Optional, Tuple
 
 # Import from core modules
-from showup_core.api_client import generate_with_claude
+from showup_core.api_client import generate_with_ai
 from .constants import EXCEL_CLARIFICATION
 from showup_core.utils import load_prompt
 from showup_core.model_config import DEFAULT_MODEL
@@ -81,7 +81,7 @@ async def compare_and_combine(generations: List[str],
             
             logger.info(f"Using token limit from UI settings: {token_limit}")
             
-            result = await generate_with_claude(
+            result = await generate_with_ai(
                 prompt=prompt,
                 system_prompt=system_prompt,
                 max_tokens=token_limit,

--- a/simplified_workflow/content_generator.py
+++ b/simplified_workflow/content_generator.py
@@ -12,7 +12,7 @@ import asyncio
 from typing import Dict, List, Any, Optional
 
 # Import from core modules
-from showup_core.api_client import generate_with_claude
+from showup_core.api_client import generate_with_ai
 # Import RAG system
 from simplified_workflow.rag_system import enhanced_generate_content
 from .constants import EXCEL_CLARIFICATION
@@ -142,7 +142,7 @@ async def generate_content(variables: Dict[str, str], template: str, settings: O
         else:
             # Call Claude API directly if no handbook is provided
             logger.info("Using direct Claude API call (no RAG)")
-            content = await generate_with_claude(
+            content = await generate_with_ai(
                 prompt=prompt,
                 system_prompt=system_prompt,
                 max_tokens=max_tokens,

--- a/simplified_workflow/content_reviewer.py
+++ b/simplified_workflow/content_reviewer.py
@@ -10,7 +10,7 @@ import asyncio
 from typing import Dict, List, Any, Optional, Tuple
 
 # Import from core modules
-from showup_core.api_client import generate_with_claude
+from showup_core.api_client import generate_with_ai
 from .constants import EXCEL_CLARIFICATION
 from showup_core.utils import load_prompt
 
@@ -67,7 +67,7 @@ async def review_content(content: str, target_learner_profile: str, instance_id:
             
             logger.info(f"Using token limit from UI settings: {token_limit}")
             
-            result = await generate_with_claude(
+            result = await generate_with_ai(
                 prompt=prompt,
                 system_prompt=system_prompt,
                 max_tokens=token_limit,

--- a/simplified_workflow/learning_sections.py
+++ b/simplified_workflow/learning_sections.py
@@ -2,7 +2,7 @@ import os
 import logging
 import re
 from typing import Tuple
-from showup_core.api_client import generate_with_claude
+from showup_core.api_client import generate_with_ai
 from showup_core.utils import load_prompt
 from showup_core.model_config import load_model_config
 
@@ -19,7 +19,7 @@ async def generate_lo_and_kt_from_content(content: str, model: str = models_cfg[
         raise FileNotFoundError('lo_kt_generation_prompt missing')
 
     prompt = prompt_template.replace('{{content}}', content)
-    response = await generate_with_claude(
+    response = await generate_with_ai(
         prompt=prompt,
         system_prompt=load_prompt('system/lo_kt_system_message'),
         max_tokens=max_tokens,

--- a/simplified_workflow/workflow.py
+++ b/simplified_workflow/workflow.py
@@ -22,7 +22,6 @@ from .content_comparator import compare_and_combine
 from .content_reviewer import review_content
 from .ai_detector import detect_ai_patterns, edit_content
 from .constants import EXCEL_CLARIFICATION
-from showup_core.api_client import generate_with_claude
 # Import RAG system components
 from simplified_workflow.rag_system.token_counter import count_tokens
 from simplified_workflow.rag_system.cache_manager import cache


### PR DESCRIPTION
## Summary
- add `generate_with_ai` wrapper to choose Claude or OpenAI
- replace direct `generate_with_claude` uses with `generate_with_ai`
- remove unused Claude import from workflow

## Testing
- `flake8 showup_core/api_client.py simplified_workflow/content_generator.py simplified_workflow/content_comparator.py simplified_workflow/content_reviewer.py simplified_workflow/learning_sections.py simplified_workflow/ai_detector.py simplified_workflow/workflow.py`


------
https://chatgpt.com/codex/tasks/task_b_6874f553194883268e5d4e031426d8f2