### PR TITLE
Remove forced model override

### DIFF
--- a/showup_tools/simplified_app.py
+++ b/showup_tools/simplified_app.py
@@ -277,17 +277,11 @@ class SimplifiedContentGeneratorApp:
                 model in models}
             self.model_id_to_display = {model['id']: model['display_name'] for
                 model in models}
-            forced_model_id = 'claude-3-7-sonnet-20250219'
+            selected_model_id = self.settings.get('selected_model', DEFAULT_MODEL)
             default_display_name = self.model_id_to_display.get(
-                forced_model_id, 'Claude 3.7 Sonnet'
+                selected_model_id, self.model_id_to_display.get(DEFAULT_MODEL)
             )
             self.model_var.set(default_display_name)
-            # ensure settings reflect the forced model
-            self.settings['selected_model'] = forced_model_id
-            self._log(
-                'Processing model forced to Claude 3.7 Sonnet during '
-                'initialization'
-            )
             default_initial_model = self.settings.get(
                 'initial_generation_model', 'claude-3-haiku-20240307')
             default_initial_display_name = self.model_id_to_display.get(
@@ -304,16 +298,11 @@ class SimplifiedContentGeneratorApp:
                 'claude-3-opus-20240229'}
             self.model_id_to_display = {v: k for k, v in self.
                 model_display_to_id.items()}
-            forced_model_id = 'claude-3-7-sonnet-20250219'
+            selected_model_id = self.settings.get('selected_model', DEFAULT_MODEL)
             default_display_name = self.model_id_to_display.get(
-                forced_model_id, 'Claude 3.7 Sonnet'
+                selected_model_id, self.model_id_to_display.get(DEFAULT_MODEL)
             )
             self.model_var.set(default_display_name)
-            self.settings['selected_model'] = forced_model_id
-            self._log(
-                'Processing model forced to Claude 3.7 Sonnet during '
-                'initialization (fallback)'
-            )
             default_initial_model = self.settings.get(
                 'initial_generation_model', 'claude-3-haiku-20240307')
             default_initial_display_name = self.model_id_to_display.get(
@@ -344,10 +333,7 @@ class SimplifiedContentGeneratorApp:
             )
         self.model_dropdown.bind('<<ComboboxSelected>>', self._on_model_changed
             )
-        self._log(
-            'Processing steps will always use Claude 3.7 Sonnet regardless of '
-            'UI selection'
-        )
+
         template_type_frame = ttk.Frame(template_settings_frame, style=
             'BG.TFrame')
         template_type_frame.pack(fill=tk.X, pady=5)
@@ -637,8 +623,9 @@ class SimplifiedContentGeneratorApp:
                 with open(self.settings_path, 'r', encoding='utf-8') as f:
                     settings = json.load(f)
             else:
+                from showup_core.model_config import DEFAULT_MODEL
                 settings = {
-                    'selected_model': 'claude-3-7-sonnet-20250219',
+                    'selected_model': DEFAULT_MODEL,
                     'initial_generation_model': 'claude-3-haiku-20240307',
                     'generation_settings': {
                         'max_tokens': 4000,
@@ -648,10 +635,8 @@ class SimplifiedContentGeneratorApp:
                 }
                 with open(self.settings_path, 'w', encoding='utf-8') as f:
                     json.dump(settings, f, indent=2)
-            # Force the processing model to Claude 3.7 Sonnet
-            settings['selected_model'] = 'claude-3-7-sonnet-20250219'
-            # Keep 'model' in sync for downstream modules
-            settings['model'] = settings['selected_model']
+            from showup_core.model_config import DEFAULT_MODEL
+            settings['model'] = settings.get('selected_model', DEFAULT_MODEL)
             return settings
         except Exception as e:
             logger.error(f'Error loading settings: {str(e)}')
@@ -660,9 +645,7 @@ class SimplifiedContentGeneratorApp:
     def _save_settings(self):
         """Save settings to settings file"""
         try:
-            # Always persist the processing model as Claude 3.7 Sonnet
-            self.settings['selected_model'] = 'claude-3-7-sonnet-20250219'
-            self.settings['model'] = self.settings['selected_model']
+            self.settings['model'] = self.settings.get('selected_model')
             with open(self.settings_path, 'w', encoding='utf-8') as f:
                 json.dump(self.settings, f, indent=2)
             logger.info(f'Settings saved successfully to {self.settings_path}')
@@ -671,21 +654,20 @@ class SimplifiedContentGeneratorApp:
 
     def _on_model_changed(self, event):
         """Handle model selection change."""
-        forced_display = self.model_id_to_display.get(
-            'claude-3-7-sonnet-20250219', 'Claude 3.7 Sonnet'
-        )
-        self.model_var.set(forced_display)
-        self.settings['selected_model'] = 'claude-3-7-sonnet-20250219'
-        self.settings['model'] = self.settings['selected_model']
-        self._save_settings()
-        self._log(
-            f'Model selection overridden to {forced_display} '
-            f'(claude-3-7-sonnet-20250219)'
-        )
-        logging.info(
-            f'Model override applied: {forced_display} '
-            f'(claude-3-7-sonnet-20250219)'
-        )
+        selected_display_name = self.model_var.get()
+        selected_model_id = self.model_display_to_id.get(selected_display_name)
+        if selected_model_id:
+            self.settings['selected_model'] = selected_model_id
+            self.settings['model'] = selected_model_id
+            self._save_settings()
+            self._log(
+                f'Changed processing model to {selected_display_name} '
+                f'({selected_model_id})'
+            )
+            logging.info(
+                f'User changed processing model to {selected_display_name} '
+                f'({selected_model_id})'
+            )
 
     def _on_initial_model_changed(self, event):
         """Handle initial generation model selection change."""
@@ -731,14 +713,25 @@ class SimplifiedContentGeneratorApp:
                     self._log(
                         f'Loaded template-specific settings for {len(self.template_settings)} templates'
                         )
-            # Ensure the processing model is always Claude 3.7 Sonnet
-            self.ui_settings['selected_model'] = 'claude-3-7-sonnet-20250219'
-            self.ui_settings['model'] = self.ui_settings['selected_model']
+            if 'selected_model' in self.ui_settings:
+                model_id = self.ui_settings['selected_model']
+                display_name = self.model_id_to_display.get(
+                    model_id, model_id
+                )
+                self.model_var.set(display_name)
+                self.settings['selected_model'] = model_id
+                self.ui_settings['model'] = model_id
+            if 'initial_generation_model' in self.ui_settings:
+                init_id = self.ui_settings['initial_generation_model']
+                init_display = self.model_id_to_display.get(
+                    init_id, init_id
+                )
+                self.initial_model_var.set(init_display)
+                self.settings['initial_generation_model'] = init_id
             self._log(
-                'Selected model from settings overridden to Claude 3.7 Sonnet'
+                f'Loaded settings: {json.dumps(self.ui_settings, indent=2)}'
             )
-            self._log(
-                f'Loaded settings: {json.dumps(self.ui_settings, indent=2)}')
+
         except Exception as e:
             error_msg = f'Error processing settings file: {str(e)}'
             self._log(error_msg, level='ERROR')
@@ -758,19 +751,10 @@ class SimplifiedContentGeneratorApp:
                 'Please select a learner profile file')
             return
         selected_model_display = self.model_var.get()
-        selected_model = self.model_display_to_id.get(selected_model_display,
-            '')
-        if selected_model != 'claude-3-7-sonnet-20250219':
-            forced_display = self.model_id_to_display.get(
-                'claude-3-7-sonnet-20250219', 'Claude 3.7 Sonnet'
-            )
-            self._log(
-                'Selected model overridden to Claude 3.7 Sonnet',
-                level='WARNING',
-            )
-            self.model_var.set(forced_display)
-            selected_model = 'claude-3-7-sonnet-20250219'
-        self.settings['selected_model'] = selected_model
+        selected_model = self.model_display_to_id.get(selected_model_display, '')
+        if selected_model:
+            self.settings['selected_model'] = selected_model
+            self._save_settings()
         initial_model_display = self.initial_model_var.get()
         initial_model = self.model_display_to_id.get(initial_model_display, '')
         use_reference_handbook = self.use_handbook_var.get()
@@ -801,10 +785,7 @@ class SimplifiedContentGeneratorApp:
             output_dir = 'output'
         self._ensure_output_dirs(output_dir)
         self._log(f'Using output directory: {output_dir}')
-        self._log(
-            'Processing steps will use Claude 3.7 Sonnet regardless of '
-            'saved settings'
-        )
+
         threading.Thread(
             target=self._run_generation,
             args=(selected_modules, None, use_reference_handbook, reference_handbook_path, output_dir),
@@ -839,20 +820,9 @@ class SimplifiedContentGeneratorApp:
                 self.word_count.get())
             updated_settings['generation_settings']['max_tokens'] = int(self
                 .token_limit.get())
-            forced_model_id = 'claude-3-7-sonnet-20250219'
-            forced_display = self.model_id_to_display.get(
-                forced_model_id, 'Claude 3.7 Sonnet'
-            )
-            if self.model_var.get() != forced_display:
-                self._log(
-                    'Processing model overridden to Claude 3.7 Sonnet',
-                    level='WARNING',
-                )
-                self.model_var.set(forced_display)
-            updated_settings['selected_model'] = forced_model_id
-            updated_settings['model'] = forced_model_id
-            self.settings['selected_model'] = forced_model_id
-            self.settings['model'] = forced_model_id
+            selected_model_id = self.settings.get('selected_model')
+            updated_settings['selected_model'] = selected_model_id
+            updated_settings['model'] = selected_model_id
             initial_model_display = self.initial_model_var.get()
             initial_model_id = self.model_display_to_id.get(
                 initial_model_display, 'claude-3-haiku-20240307')

--- a/showup_tools/simplified_app/simplified_app.py
+++ b/showup_tools/simplified_app/simplified_app.py
@@ -277,17 +277,11 @@ class SimplifiedContentGeneratorApp:
                 model in models}
             self.model_id_to_display = {model['id']: model['display_name'] for
                 model in models}
-            forced_model_id = 'claude-3-7-sonnet-20250219'
+            selected_model_id = self.settings.get('selected_model', DEFAULT_MODEL)
             default_display_name = self.model_id_to_display.get(
-                forced_model_id, 'Claude 3.7 Sonnet'
+                selected_model_id, self.model_id_to_display.get(DEFAULT_MODEL)
             )
             self.model_var.set(default_display_name)
-            # ensure settings reflect the forced model
-            self.settings['selected_model'] = forced_model_id
-            self._log(
-                'Processing model forced to Claude 3.7 Sonnet during '
-                'initialization'
-            )
             default_initial_model = self.settings.get(
                 'initial_generation_model', 'claude-3-haiku-20240307')
             default_initial_display_name = self.model_id_to_display.get(
@@ -304,16 +298,11 @@ class SimplifiedContentGeneratorApp:
                 'claude-3-opus-20240229'}
             self.model_id_to_display = {v: k for k, v in self.
                 model_display_to_id.items()}
-            forced_model_id = 'claude-3-7-sonnet-20250219'
+            selected_model_id = self.settings.get('selected_model', DEFAULT_MODEL)
             default_display_name = self.model_id_to_display.get(
-                forced_model_id, 'Claude 3.7 Sonnet'
+                selected_model_id, self.model_id_to_display.get(DEFAULT_MODEL)
             )
             self.model_var.set(default_display_name)
-            self.settings['selected_model'] = forced_model_id
-            self._log(
-                'Processing model forced to Claude 3.7 Sonnet during '
-                'initialization (fallback)'
-            )
             default_initial_model = self.settings.get(
                 'initial_generation_model', 'claude-3-haiku-20240307')
             default_initial_display_name = self.model_id_to_display.get(
@@ -344,10 +333,7 @@ class SimplifiedContentGeneratorApp:
             )
         self.model_dropdown.bind('<<ComboboxSelected>>', self._on_model_changed
             )
-        self._log(
-            'Processing steps will always use Claude 3.7 Sonnet regardless of '
-            'UI selection'
-        )
+
         template_type_frame = ttk.Frame(template_settings_frame, style=
             'BG.TFrame')
         template_type_frame.pack(fill=tk.X, pady=5)
@@ -637,8 +623,9 @@ class SimplifiedContentGeneratorApp:
                 with open(self.settings_path, 'r', encoding='utf-8') as f:
                     settings = json.load(f)
             else:
+                from showup_core.model_config import DEFAULT_MODEL
                 settings = {
-                    'selected_model': 'claude-3-7-sonnet-20250219',
+                    'selected_model': DEFAULT_MODEL,
                     'initial_generation_model': 'claude-3-haiku-20240307',
                     'generation_settings': {
                         'max_tokens': 4000,
@@ -648,10 +635,8 @@ class SimplifiedContentGeneratorApp:
                 }
                 with open(self.settings_path, 'w', encoding='utf-8') as f:
                     json.dump(settings, f, indent=2)
-            # Force the processing model to Claude 3.7 Sonnet
-            settings['selected_model'] = 'claude-3-7-sonnet-20250219'
-            # Keep 'model' in sync for downstream modules
-            settings['model'] = settings['selected_model']
+            from showup_core.model_config import DEFAULT_MODEL
+            settings['model'] = settings.get('selected_model', DEFAULT_MODEL)
             return settings
         except Exception as e:
             logger.error(f'Error loading settings: {str(e)}')
@@ -660,9 +645,7 @@ class SimplifiedContentGeneratorApp:
     def _save_settings(self):
         """Save settings to settings file"""
         try:
-            # Always persist the processing model as Claude 3.7 Sonnet
-            self.settings['selected_model'] = 'claude-3-7-sonnet-20250219'
-            self.settings['model'] = self.settings['selected_model']
+            self.settings['model'] = self.settings.get('selected_model')
             with open(self.settings_path, 'w', encoding='utf-8') as f:
                 json.dump(self.settings, f, indent=2)
             logger.info(f'Settings saved successfully to {self.settings_path}')
@@ -671,21 +654,20 @@ class SimplifiedContentGeneratorApp:
 
     def _on_model_changed(self, event):
         """Handle model selection change."""
-        forced_display = self.model_id_to_display.get(
-            'claude-3-7-sonnet-20250219', 'Claude 3.7 Sonnet'
-        )
-        self.model_var.set(forced_display)
-        self.settings['selected_model'] = 'claude-3-7-sonnet-20250219'
-        self.settings['model'] = self.settings['selected_model']
-        self._save_settings()
-        self._log(
-            f'Model selection overridden to {forced_display} '
-            f'(claude-3-7-sonnet-20250219)'
-        )
-        logging.info(
-            f'Model override applied: {forced_display} '
-            f'(claude-3-7-sonnet-20250219)'
-        )
+        selected_display_name = self.model_var.get()
+        selected_model_id = self.model_display_to_id.get(selected_display_name)
+        if selected_model_id:
+            self.settings['selected_model'] = selected_model_id
+            self.settings['model'] = selected_model_id
+            self._save_settings()
+            self._log(
+                f'Changed processing model to {selected_display_name} '
+                f'({selected_model_id})'
+            )
+            logging.info(
+                f'User changed processing model to {selected_display_name} '
+                f'({selected_model_id})'
+            )
 
     def _on_initial_model_changed(self, event):
         """Handle initial generation model selection change."""
@@ -731,14 +713,25 @@ class SimplifiedContentGeneratorApp:
                     self._log(
                         f'Loaded template-specific settings for {len(self.template_settings)} templates'
                         )
-            # Ensure the processing model is always Claude 3.7 Sonnet
-            self.ui_settings['selected_model'] = 'claude-3-7-sonnet-20250219'
-            self.ui_settings['model'] = self.ui_settings['selected_model']
+            if 'selected_model' in self.ui_settings:
+                model_id = self.ui_settings['selected_model']
+                display_name = self.model_id_to_display.get(
+                    model_id, model_id
+                )
+                self.model_var.set(display_name)
+                self.settings['selected_model'] = model_id
+                self.ui_settings['model'] = model_id
+            if 'initial_generation_model' in self.ui_settings:
+                init_id = self.ui_settings['initial_generation_model']
+                init_display = self.model_id_to_display.get(
+                    init_id, init_id
+                )
+                self.initial_model_var.set(init_display)
+                self.settings['initial_generation_model'] = init_id
             self._log(
-                'Selected model from settings overridden to Claude 3.7 Sonnet'
+                f'Loaded settings: {json.dumps(self.ui_settings, indent=2)}'
             )
-            self._log(
-                f'Loaded settings: {json.dumps(self.ui_settings, indent=2)}')
+
         except Exception as e:
             error_msg = f'Error processing settings file: {str(e)}'
             self._log(error_msg, level='ERROR')
@@ -758,19 +751,10 @@ class SimplifiedContentGeneratorApp:
                 'Please select a learner profile file')
             return
         selected_model_display = self.model_var.get()
-        selected_model = self.model_display_to_id.get(selected_model_display,
-            '')
-        if selected_model != 'claude-3-7-sonnet-20250219':
-            forced_display = self.model_id_to_display.get(
-                'claude-3-7-sonnet-20250219', 'Claude 3.7 Sonnet'
-            )
-            self._log(
-                'Selected model overridden to Claude 3.7 Sonnet',
-                level='WARNING',
-            )
-            self.model_var.set(forced_display)
-            selected_model = 'claude-3-7-sonnet-20250219'
-        self.settings['selected_model'] = selected_model
+        selected_model = self.model_display_to_id.get(selected_model_display, '')
+        if selected_model:
+            self.settings['selected_model'] = selected_model
+            self._save_settings()
         initial_model_display = self.initial_model_var.get()
         initial_model = self.model_display_to_id.get(initial_model_display, '')
         use_reference_handbook = self.use_handbook_var.get()
@@ -801,10 +785,7 @@ class SimplifiedContentGeneratorApp:
             output_dir = 'output'
         self._ensure_output_dirs(output_dir)
         self._log(f'Using output directory: {output_dir}')
-        self._log(
-            'Processing steps will use Claude 3.7 Sonnet regardless of '
-            'saved settings'
-        )
+
         threading.Thread(
             target=self._run_generation,
             args=(selected_modules, None, use_reference_handbook, reference_handbook_path, output_dir),
@@ -839,20 +820,9 @@ class SimplifiedContentGeneratorApp:
                 self.word_count.get())
             updated_settings['generation_settings']['max_tokens'] = int(self
                 .token_limit.get())
-            forced_model_id = 'claude-3-7-sonnet-20250219'
-            forced_display = self.model_id_to_display.get(
-                forced_model_id, 'Claude 3.7 Sonnet'
-            )
-            if self.model_var.get() != forced_display:
-                self._log(
-                    'Processing model overridden to Claude 3.7 Sonnet',
-                    level='WARNING',
-                )
-                self.model_var.set(forced_display)
-            updated_settings['selected_model'] = forced_model_id
-            updated_settings['model'] = forced_model_id
-            self.settings['selected_model'] = forced_model_id
-            self.settings['model'] = forced_model_id
+            selected_model_id = self.settings.get('selected_model')
+            updated_settings['selected_model'] = selected_model_id
+            updated_settings['model'] = selected_model_id
             initial_model_display = self.initial_model_var.get()
             initial_model_id = self.model_display_to_id.get(
                 initial_model_display, 'claude-3-haiku-20240307')

--- a/user_settings.json
+++ b/user_settings.json
@@ -1,0 +1,6 @@
+{
+  "selected_model": "openai/o3-2025-04-16",
+  "initial_generation_model": "openai/o3-mini-2025-01-31",
+  "generation_settings": {},
+  "use_dynamic_blocks": true
+}


### PR DESCRIPTION
## Summary
- load model from `user_settings.json` instead of forcing Claude
- persist chosen model when saving settings
- update content generation to honor selected model
- include a default `user_settings.json`

## Testing
- `python -m py_compile showup_tools/simplified_app.py showup_tools/simplified_app/simplified_app.py`

------
https://chatgpt.com/codex/tasks/task_b_6875013f38a4832697893bcfc158e787