### PR TITLE
Use user selected model as default

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from kivy.uix.progressbar import ProgressBar
 from kivy.clock import Clock
 from kivy.properties import StringProperty, BooleanProperty, NumericProperty
 from showup_core.model_config import DEFAULT_PLANNING_MODEL, load_model_config
+from showup_core.api_client import _load_selected_model
 from showup_core.config import create_argument_parser
 
 import asyncio
@@ -209,12 +210,12 @@ class WorkflowApp(App):
         ui_settings = {
             "use_reference_handbook": bool(abs_handbook_path),
             "reference_handbook_path": abs_handbook_path,
-            "selected_model": DEFAULT_PLANNING_MODEL,
+            "selected_model": _load_selected_model(DEFAULT_PLANNING_MODEL),
             "initial_generation_model": models_cfg["generation_model"],
             "comparison_model": models_cfg["comparison_model"],
             "review_model": models_cfg["review_model"],
-            "planning_model": DEFAULT_PLANNING_MODEL,
-            "refinement_model": DEFAULT_PLANNING_MODEL,
+            "planning_model": _load_selected_model(DEFAULT_PLANNING_MODEL),
+            "refinement_model": _load_selected_model(DEFAULT_PLANNING_MODEL),
             "planning_max_tokens": 8000,
             "refinement_max_tokens": 8000,
             "planning_temperature": 0.3,

--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 from typing import Dict, Any
 
-from showup_core.api_client import generate_with_claude
+from showup_core.api_client import generate_with_claude, _load_selected_model
 from showup_core.model_config import (
     get_model_provider,
     DEFAULT_PLANNING_MODEL,
@@ -51,7 +51,7 @@ async def run_planning_stage(
         .replace("{{block_library}}", block_defs)
     )
 
-    model_id = config.get('model_id', DEFAULT_PLANNING_MODEL)
+    model_id = config.get('model_id', _load_selected_model(DEFAULT_PLANNING_MODEL))
     provider = get_model_provider(model_id)
 
     max_attempts = config.get("max_attempts", 3)

--- a/showup_tools/workflow.py
+++ b/showup_tools/workflow.py
@@ -29,7 +29,7 @@ from simplified_workflow.learning_sections import generate_lo_and_kt_from_conten
 from simplified_workflow.markdown_utils import insert_sections_in_markdown
 from .constants import EXCEL_CLARIFICATION
 
-from showup_core.api_client import generate_with_claude
+from showup_core.api_client import generate_with_claude, _load_selected_model
 from showup_core.model_config import DEFAULT_PLANNING_MODEL
 # Import RAG system components
 from simplified_workflow.rag_system.token_counter import count_tokens
@@ -355,7 +355,9 @@ async def process_row_for_phase(row_data_item: Dict[str, Any], phase: str, csv_r
             plan_cfg = {
                 "model_id": ui_settings.get(
                     "planning_model",
-                    ui_settings.get("selected_model", DEFAULT_PLANNING_MODEL),
+                    ui_settings.get(
+                        "selected_model", _load_selected_model(DEFAULT_PLANNING_MODEL)
+                    ),
                 ),
                 "max_tokens": ui_settings.get("planning_max_tokens", 8000),
                 "temperature": ui_settings.get("planning_temperature", 0.3),
@@ -387,7 +389,10 @@ async def process_row_for_phase(row_data_item: Dict[str, Any], phase: str, csv_r
             add_log_entry("Refinement", "started", "Refining plan")
             refine_cfg = {
                 "model_id": ui_settings.get(
-                    "refinement_model", ui_settings.get("selected_model", DEFAULT_PLANNING_MODEL)
+                    "refinement_model",
+                    ui_settings.get(
+                        "selected_model", _load_selected_model(DEFAULT_PLANNING_MODEL)
+                    ),
                 ),
                 "max_tokens": ui_settings.get("refinement_max_tokens", 8000),
                 "temperature": ui_settings.get("refinement_temperature", 0.3),


### PR DESCRIPTION
## Summary
- update planning stage to load the user's selected model
- default to selected model during workflow planning/refinement
- propagate selected model through UI settings

## Testing
- `python -m py_compile showup_tools/planning_stage.py showup_tools/workflow.py main.py`

------
https://chatgpt.com/codex/tasks/task_b_6875108a1f388326a82af46231e956ea