### PR TITLE
Overlay user model settings

### DIFF
--- a/showup_core/model_config.py
+++ b/showup_core/model_config.py
@@ -2,16 +2,51 @@
 
 import json
 import pathlib
+from .config import get_project_root
+import logging
 
 _CACHE = None
 
 
-def load_model_config():
-    """Load model configuration from JSON file (cached)."""
+def load_user_model_settings() -> dict:
+    """Return model-related settings from the root ``user_settings.json``."""
+    settings_file = get_project_root() / "user_settings.json"
+    if not settings_file.exists():
+        return {}
+
+    try:
+        data = json.loads(settings_file.read_text())
+    except Exception as exc:  # pragma: no cover - best effort
+        logging.getLogger(__name__).warning(
+            "Failed to load user model settings: %s", exc
+        )
+        return {}
+
+    model_keys = {
+        k
+        for k in data.keys()
+        if k.endswith("_model") or k in {"selected_model", "initial_generation_model"}
+    }
+    return {k: data[k] for k in model_keys}
+
+
+def load_model_config() -> dict:
+    """Load base model settings and overlay any user-specific selections."""
     global _CACHE
     if _CACHE is None:
-        path = pathlib.Path(__file__).parent.parent / "config" / "model_settings.json"
-        _CACHE = json.loads(path.read_text())
+        base_path = get_project_root() / "config" / "model_settings.json"
+        try:
+            config = json.loads(base_path.read_text())
+        except Exception as exc:  # pragma: no cover - best effort
+            logging.getLogger(__name__).warning(
+                "Failed to load model_settings.json: %s", exc
+            )
+            config = {}
+
+        user_cfg = load_user_model_settings()
+        config.update(user_cfg)
+        _CACHE = config
+
     return _CACHE
 
 

--- a/simplified_workflow/learning_sections.py
+++ b/simplified_workflow/learning_sections.py
@@ -6,13 +6,13 @@ from showup_core.api_client import generate_with_ai
 from showup_core.utils import load_prompt
 from showup_core.model_config import load_model_config
 
-models_cfg = load_model_config()
-
 logger = logging.getLogger(__name__)
 
 
-async def generate_lo_and_kt_from_content(content: str, model: str = models_cfg["lo_kt_model"], max_tokens: int = 800) -> Tuple[str, str]:
+async def generate_lo_and_kt_from_content(content: str, model: str | None = None, max_tokens: int = 800) -> Tuple[str, str]:
     """Generate learning objectives and key takeaways from lesson content."""
+    if model is None:
+        model = load_model_config().get("lo_kt_model")
     prompt_template = load_prompt('generation/lo_kt_generation_prompt')
     if not prompt_template:
         logger.error('Prompt file not found')


### PR DESCRIPTION
## Summary
- load `user_settings.json` via new `load_user_model_settings`
- overlay loaded settings onto defaults in `load_model_config`
- default LO/KT generation now uses `load_model_config` at runtime

## Testing
- `python -m py_compile showup_core/model_config.py simplified_workflow/learning_sections.py`


------
https://chatgpt.com/codex/tasks/task_b_6875108b99e48326b5f76849086e00b2