### PR TITLE
Fix max_tokens for OpenAI calls

### DIFF
--- a/showup_core/api_client.py
+++ b/showup_core/api_client.py
@@ -300,29 +300,35 @@ def get_api_client(
 
 
 def get_model_max_tokens(model: str) -> int:
-    """
-    Get the maximum allowed output tokens for a specific Claude model.
+    """Return max completion tokens for a Claude model."""
 
-    Args:
-        model: Claude model name
-
-    Returns:
-        Maximum allowed output tokens for the model
-    """
-    # Define maximum token limits for each model
     model_limits = {
-        # Claude 3 models
-        "claude-3-opus-20240229": 4096,  # Claude 3 Opus
-        "claude-3-sonnet-20240229": 4096,  # Claude 3 Sonnet
-        "claude-3-haiku-20240307": 4096,  # Claude 3 Haiku
-        "claude-3-5-sonnet-20240620": 8192,  # Claude 3.5 Sonnet
-        "claude-3-7-sonnet-20250219": 8192,  # Claude 3.7 Sonnet
-        # Default for any unspecified model
+        "claude-3-opus-20240229": 4096,
+        "claude-3-sonnet-20240229": 4096,
+        "claude-3-haiku-20240307": 4096,
+        "claude-3-5-sonnet-20240620": 8192,
+        "claude-3-7-sonnet-20250219": 8192,
         "default": 4000,
     }
 
-    # Return the limit for the specified model, or the default if not found
     return model_limits.get(model, model_limits["default"])
+
+
+def get_openai_model_max_tokens(model: str) -> int:
+    """Return max completion tokens for an OpenAI chat model."""
+
+    model_limits = {
+        "gpt-4o": 4096,
+        "gpt-4": 4096,
+        "gpt-3.5-turbo": 4096,
+        "default": 4096,
+    }
+
+    for key, limit in model_limits.items():
+        if model.startswith(key):
+            return limit
+
+    return model_limits["default"]
 
 
 async def generate_with_claude(

--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -60,11 +60,22 @@ async def run_planning_stage(
         try:
             if provider == 'openai':
                 import openai
+                from showup_core.api_client import get_openai_model_max_tokens
+
                 client = openai.OpenAI(api_key=config.get('openai_api_key'))
+
+                max_tokens = config.get('max_tokens', 8000)
+                limit = get_openai_model_max_tokens(model_id)
+                if max_tokens > limit:
+                    logger.debug(
+                        f"Reducing max_tokens from {max_tokens} to {limit} for model {model_id}"
+                    )
+                    max_tokens = limit
+
                 response = client.chat.completions.create(
                     model=model_id,
                     messages=[{"role": "user", "content": prompt}],
-                    max_tokens=config.get('max_tokens', 8000),
+                    max_tokens=max_tokens,
                     temperature=config.get('temperature', 0.3)
                 )
                 ai_response = response.choices[0].message.content

--- a/showup_tools/refinement_stage.py
+++ b/showup_tools/refinement_stage.py
@@ -44,11 +44,21 @@ async def run_refinement_stage(
 
     try:
         import openai
+        from showup_core.api_client import get_openai_model_max_tokens
+
         client = openai.OpenAI(api_key=config.get('openai_api_key'))
+        max_tokens = config.get('max_tokens', 1000)
+        limit = get_openai_model_max_tokens(model_id)
+        if max_tokens > limit:
+            logger.debug(
+                f"Reducing max_tokens from {max_tokens} to {limit} for model {model_id}"
+            )
+            max_tokens = limit
+
         response = client.chat.completions.create(
             model=model_id,
             messages=[{"role": "user", "content": critique_prompt}],
-            max_tokens=config.get('max_tokens', 1000),
+            max_tokens=max_tokens,
             temperature=config.get('temperature', 0.3)
         )
         critique = response.choices[0].message.content
@@ -62,7 +72,7 @@ async def run_refinement_stage(
         response2 = client.chat.completions.create(
             model=model_id,
             messages=[{"role": "user", "content": refine_prompt}],
-            max_tokens=config.get('max_tokens', 1000),
+            max_tokens=max_tokens,
             temperature=config.get('temperature', 0.3)
         )
         revised_plan_text = response2.choices[0].message.content


### PR DESCRIPTION
## Summary
- add helper `get_openai_model_max_tokens` to return limits for OpenAI models
- use this helper in planning and refinement stages to cap `max_tokens`

## Testing
- `python -m py_compile showup_core/api_client.py showup_tools/planning_stage.py showup_tools/refinement_stage.py`

------
https://chatgpt.com/codex/tasks/task_b_68751899a77c8326be2b4ddea1c0f212