### PR TITLE
Enable plan JSON repair during refinement

### DIFF
--- a/prompts/planning/plan_refine_prompt.txt
+++ b/prompts/planning/plan_refine_prompt.txt
@@ -34,3 +34,4 @@ Example of the correct root structure:
   ]
 }
 ```
+Output MUST be the JSON object only. Do not include markdown, code fences, or explanatory text.

--- a/showup_tools/refinement_stage.py
+++ b/showup_tools/refinement_stage.py
@@ -1,10 +1,10 @@
-import os
 import json
 import logging
 from typing import Dict, Any
 
 from showup_core.utils import load_prompt
 from .block_library import get_block_type_definitions, validate_plan
+from .planning_stage import repair_plan_json_with_llm
 from simplified_workflow.template_builder import generate_markdown_template
 
 logger = logging.getLogger(__name__)
@@ -77,7 +77,19 @@ async def run_refinement_stage(
         )
         revised_plan_text = response2.choices[0].message.content
 
-        new_item["final_plan"] = validate_plan(revised_plan_text).model_dump(exclude_none=True)
+        try:
+            new_item["final_plan"] = validate_plan(revised_plan_text).model_dump(exclude_none=True)
+        except Exception as val_err:
+            logger.error(f"Refined plan validation failed: {val_err}")
+            repaired = await repair_plan_json_with_llm(
+                broken_text=revised_plan_text,
+                api_key=config.get("openai_api_key"),
+                model=model_id,
+            )
+            if repaired:
+                new_item["final_plan"] = repaired.model_dump(exclude_none=True)
+            else:
+                raise
 
         try:
             template = await generate_markdown_template(new_item["final_plan"], config)


### PR DESCRIPTION
## Summary
- repair malformed plan JSON in refinement stage using OpenAI
- enforce JSON-only output in the refinement prompt

## Testing
- `flake8 showup_tools/refinement_stage.py`
- `python -m py_compile showup_tools/refinement_stage.py`

------
https://chatgpt.com/codex/tasks/task_b_68751f7ec4ac8326b6bc9592ec17f89b