### PR TITLE
Document dynamic PlanModel usage

### DIFF
--- a/showup_tools/models/generation_output.py
+++ b/showup_tools/models/generation_output.py
@@ -246,11 +246,14 @@ AnyBlock = Annotated[
 
 
 class PlanModel(StrictBaseModel):
-    """Represents the entire lesson plan structure."""
+    """Deprecated static schema for a lesson plan.
 
-    # Deprecated: The active PlanModel is dynamically built from
-    # ``showup_tools.block_library.BLOCK_LIBRARY``. This static class
-    # remains for type hints only and may drift from the prompts.
+    Runtime validation relies on the dynamically generated
+    :class:`showup_tools.block_library.PlanModel` built from
+    ``BLOCK_LIBRARY``. This class remains only for IDE type hints and
+    may drift from the actual prompt schema.
+    """
+
     content_title: str
     target_audience: str
     estimated_word_count: int

--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -11,8 +11,8 @@ from showup_core.utils import load_prompt
 from .block_library import (
     get_block_type_definitions,
     validate_plan,
-    PlanModel,
 )
+from .models import PlanModel
 from .openai_dynamic_generation import get_instructor_client
 
 


### PR DESCRIPTION
## Summary
- clarify in `PlanModel` docstring that runtime validation relies on `block_library.PlanModel`
- import `PlanModel` from `showup_tools.models` in `planning_stage`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68752e5ec5648326b4917d54638c7449