### PR TITLE
Make template and handbook paths configurable

### DIFF
--- a/simplified_workflow/content_generator.py
+++ b/simplified_workflow/content_generator.py
@@ -17,6 +17,7 @@ from showup_core.api_client import generate_with_ai
 from simplified_workflow.rag_system import enhanced_generate_content
 from .constants import EXCEL_CLARIFICATION
 from showup_core.utils import load_prompt
+from showup_core.core.path_utils import get_template_base_dir
 
 # Set up logger
 logger = logging.getLogger("simplified_workflow.content_generator")
@@ -310,8 +311,8 @@ def load_content_generation_template() -> str:
     # 3. The system maintains a fallback mechanism below to prevent workflow failures
     #    if templates are missing
     
-    # Path to templates directory specified by user
-    template_dir = r"C:\Users\User\Desktop\ShowupSquaredV4 (2)\ShowupSquaredV4\ShowupSquaredV4\showup_tools\simplified_app\templates"
+    # Resolve the template directory from configuration or repository root
+    template_dir = str(get_template_base_dir())
     template_path = os.path.join(template_dir, "high-school-lesson-template.md")
     
     logger.info(f"Loading content generation template from {template_path}")

--- a/simplified_workflow/rag_system/demo_token_savings.py
+++ b/simplified_workflow/rag_system/demo_token_savings.py
@@ -12,6 +12,8 @@ import os
 import asyncio
 import hashlib
 import logging
+from pathlib import Path
+from showup_core.core.path_utils import get_project_root
 
 # Configure logging
 logging.basicConfig(
@@ -19,6 +21,12 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+# Default handbook location for the demonstration
+DEFAULT_HANDBOOK_PATH = os.getenv(
+    "SHOWUP_HANDBOOK_PATH",
+    str(Path(get_project_root()) / "data" / "handbook.md")
+)
 
 # Import our RAG components (with relative imports for standalone script)
 from .token_counter import count_tokens
@@ -137,7 +145,7 @@ async def demo_specific_queries(handbook_path):
 
 async def main():
     """Main demo function"""
-    handbook_path = "C:\\Users\\User\\Desktop\\ShowupSquaredV4 (2)\\ShowupSquaredV4\\ShowupSquaredV4\\showup-tools\\simplified_app\\EHS Student Catalog_Handbook from Canva.md"
+    handbook_path = DEFAULT_HANDBOOK_PATH
     
     if not os.path.exists(handbook_path):
         logger.error(f"Handbook not found: {handbook_path}")

--- a/simplified_workflow/rag_system/rag_integration.py
+++ b/simplified_workflow/rag_system/rag_integration.py
@@ -14,6 +14,8 @@ import asyncio
 import hashlib
 import logging
 from typing import Dict, Any, Optional
+from pathlib import Path
+from showup_core.core.path_utils import get_project_root
 
 # Import our RAG components
 from .token_counter import count_tokens
@@ -22,6 +24,12 @@ from .textbook_vector_db import get_vector_db
 
 # Configure logging
 logger = logging.getLogger(__name__)
+
+# Default handbook location, configurable via environment variable
+DEFAULT_HANDBOOK_PATH = os.getenv(
+    "SHOWUP_HANDBOOK_PATH",
+    str(Path(get_project_root()) / "data" / "handbook.md")
+)
 
 
 async def generate_with_claude_rag(prompt: str, 
@@ -260,7 +268,7 @@ async def main():
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
     
-    handbook_path = "C:\\Users\\User\\Desktop\\ShowupSquaredV4 (2)\\ShowupSquaredV4\\ShowupSquaredV4\\showup-tools\\simplified_app\\EHS Student Catalog_Handbook from Canva.md"
+    handbook_path = DEFAULT_HANDBOOK_PATH
     
     if not os.path.exists(handbook_path):
         logger.error(f"Handbook not found: {handbook_path}")


### PR DESCRIPTION
## Summary
- use `get_template_base_dir` when loading content generation template
- remove hard-coded handbook paths and rely on `SHOWUP_HANDBOOK_PATH` or repo defaults

## Testing
- `python -m py_compile simplified_workflow/content_generator.py simplified_workflow/rag_system/rag_integration.py simplified_workflow/rag_system/demo_token_savings.py`

------
https://chatgpt.com/codex/tasks/task_b_68752df722048326b8dc3a1c58172c2b