### PR TITLE
Improve prompt loading failure handling

### DIFF
--- a/showup_core/utils.py
+++ b/showup_core/utils.py
@@ -77,8 +77,10 @@ def load_prompt(prompt_name: str) -> str:
                       (e.g., 'planning/lesson_plan').
 
     Returns:
-        The content of the prompt file as a string. Returns an empty string if
-        the file cannot be found.
+        The content of the prompt file as a string.
+
+    Raises:
+        FileNotFoundError: If the prompt file does not exist.
     """
     root_dir = get_project_root()
     prompt_path = os.path.join(root_dir, 'prompts', f"{prompt_name}.txt")
@@ -86,5 +88,5 @@ def load_prompt(prompt_name: str) -> str:
         with open(prompt_path, 'r', encoding='utf-8') as f:
             return f.read()
     except FileNotFoundError:
-        print(f"Error: Prompt file not found at {prompt_path}")
-        return ""
+        logger.error("Prompt file not found at %s", prompt_path)
+        raise

--- a/showup_tools/content_generator.py
+++ b/showup_tools/content_generator.py
@@ -191,10 +191,11 @@ async def generate_three_versions_from_plan(
     use_dynamic = ui_settings.get("use_dynamic_blocks", True) and not template
     system_prompt = load_prompt("system/ai_editor_system_message")
 
-    prompt_template = load_prompt("generation/generation_prompt")
-    if not prompt_template:
+    try:
+        prompt_template = load_prompt("generation/generation_prompt")
+    except FileNotFoundError:
         logger.error("Generation prompt not found")
-        raise FileNotFoundError("generation prompt missing")
+        raise
 
     max_tokens = ui_settings.get("generation_settings", {}).get("max_tokens", 4000)
     freq_pen = ui_settings.get("generation_settings", {}).get("frequency_penalty", 0.0)

--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -57,8 +57,9 @@ async def run_planning_stage(
     new_item = row_data_item.copy()
 
     prompt_path = config.get("planning_prompt_path") or "planning/main_lesson_planner"
-    prompt_template = load_prompt(prompt_path)
-    if not prompt_template:
+    try:
+        prompt_template = load_prompt(prompt_path)
+    except FileNotFoundError:
         logger.error("Planning prompt not found")
         new_item["status"] = "PLAN_FAILED"
         new_item["error"] = "Prompt not found"

--- a/showup_tools/refinement_stage.py
+++ b/showup_tools/refinement_stage.py
@@ -20,9 +20,10 @@ async def run_refinement_stage(
 
     critique_path = config.get("critique_prompt_path") or "planning/plan_critique_prompt"
     refine_path = config.get("refine_prompt_path") or "planning/plan_refine_prompt"
-    critique_template = load_prompt(critique_path)
-    refine_template = load_prompt(refine_path)
-    if not critique_template or not refine_template:
+    try:
+        critique_template = load_prompt(critique_path)
+        refine_template = load_prompt(refine_path)
+    except FileNotFoundError:
         logger.error("Refinement prompts not found")
         new_item["status"] = "PLAN_FAILED"
         new_item["error"] = "Prompt not found"

--- a/simplified_workflow/learning_sections.py
+++ b/simplified_workflow/learning_sections.py
@@ -13,10 +13,11 @@ async def generate_lo_and_kt_from_content(content: str, model: str | None = None
     """Generate learning objectives and key takeaways from lesson content."""
     if model is None:
         model = load_model_config().get("lo_kt_model")
-    prompt_template = load_prompt('generation/lo_kt_generation_prompt')
-    if not prompt_template:
+    try:
+        prompt_template = load_prompt('generation/lo_kt_generation_prompt')
+    except FileNotFoundError:
         logger.error('Prompt file not found')
-        raise FileNotFoundError('lo_kt_generation_prompt missing')
+        raise
 
     prompt = prompt_template.replace('{{content}}', content)
     response = await generate_with_ai(

--- a/simplified_workflow/template_builder.py
+++ b/simplified_workflow/template_builder.py
@@ -22,10 +22,11 @@ async def generate_markdown_template(plan: Dict[str, Any], settings: Dict[str, A
     """
     logger.info("Generating markdown template from plan")
 
-    prompt_template = load_prompt("planning/generate_template_from_plan")
-    if not prompt_template:
+    try:
+        prompt_template = load_prompt("planning/generate_template_from_plan")
+    except FileNotFoundError:
         logger.error("Template generation prompt not found")
-        raise FileNotFoundError("generate_template_from_plan prompt missing")
+        raise
 
     plan_str = json.dumps(plan, ensure_ascii=False)
     prompt = prompt_template.replace("{{final_plan}}", plan_str)


### PR DESCRIPTION
## Summary
- raise `FileNotFoundError` when a prompt is missing
- update callers to handle the new exception

## Testing
- `git commit -m "Raise FileNotFoundError when prompts missing"`

------
https://chatgpt.com/codex/tasks/task_b_68752e0347d48326a8184f55b9fa5cc6