### PR TITLE
Fix planning stage variable merge

### DIFF
--- a/showup_tools/planning_stage.py
+++ b/showup_tools/planning_stage.py
@@ -55,6 +55,9 @@ async def run_planning_stage(
     logger.info("Running planning stage")
 
     new_item = row_data_item.copy()
+    # Merge in nested dictionaries so prompt variables are accessible
+    new_item.update(row_data_item.get("variables", {}))
+    new_item.update(row_data_item.get("row", {}))
 
     prompt_path = config.get("planning_prompt_path") or "planning/main_lesson_planner"
     try:

--- a/tests/test_planning_stage.py
+++ b/tests/test_planning_stage.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import patch, AsyncMock
+
+from showup_tools.planning_stage import run_planning_stage
+
+class TestPlanningStage(unittest.IsolatedAsyncioTestCase):
+    async def test_prompt_uses_row_values(self):
+        row = {
+            "Content Outline": "Outline from row",
+            "Learner Profile": "Learner from row"
+        }
+        variables = {
+            "content_outline": "Outline from variables",
+            "target_learner": "Learner from variables",
+            "topic": "Photography"
+        }
+        row_data_item = {
+            "row": row,
+            "variables": variables,
+            "word_count": 50
+        }
+        config = {"model_id": "claude-test"}
+
+        prompt_template = "Outline: {{content_outline}} | Learner: {{learner_profile}}"
+
+        with patch("showup_tools.planning_stage.load_prompt", return_value=prompt_template), \
+             patch("showup_tools.planning_stage.get_block_type_definitions", return_value=""), \
+             patch("showup_tools.planning_stage.generate_with_claude", new=AsyncMock(return_value='{"content_blocks": []}')) as mock_gen, \
+             patch("showup_tools.planning_stage.validate_plan") as mock_validate:
+            mock_validate.return_value.model_dump.return_value = {"content_blocks": []}
+            result = await run_planning_stage(row_data_item, config)
+
+        mock_gen.assert_awaited()
+        used_prompt = mock_gen.call_args[0][0]
+        self.assertIn("Outline from row", used_prompt)
+        self.assertIn("Learner from row", used_prompt)
+        self.assertEqual(result["status"], "PLAN_GENERATED")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- merge `variables` and `row` dictionaries into `run_planning_stage`
- add tests for planning prompt construction using row data

## Testing
- `flake8 tests/test_planning_stage.py showup_tools/planning_stage.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68753fb3852c83269cb0e636bb1ed110