### PR TITLE
allow custom initial generation model

### DIFF
--- a/main.py
+++ b/main.py
@@ -211,7 +211,9 @@ class WorkflowApp(App):
             "use_reference_handbook": bool(abs_handbook_path),
             "reference_handbook_path": abs_handbook_path,
             "selected_model": _load_selected_model(DEFAULT_PLANNING_MODEL),
-            "initial_generation_model": models_cfg["generation_model"],
+            "initial_generation_model": models_cfg.get(
+                "initial_generation_model", models_cfg["generation_model"]
+            ),
             "comparison_model": models_cfg["comparison_model"],
             "review_model": models_cfg["review_model"],
             "planning_model": _load_selected_model(DEFAULT_PLANNING_MODEL),


### PR DESCRIPTION
## Summary
- support `initial_generation_model` override when starting workflow
- confirm logs show OpenAI model usage

## Testing
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_b_687543bf51948326b9594621adcaf171